### PR TITLE
[xml-conduit] Fix space leak.

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE BangPatterns #-}
 -- | This module provides both a native Haskell solution for parsing XML
 -- documents into a stream of events, and a set of parser combinators for
 -- dealing with a stream of events.
@@ -277,7 +278,7 @@ toEventC :: Monad m => Conduit (PositionRange, Token) m EventPos
 toEventC =
     go [] []
   where
-    go es levels =
+    go !es !levels =
         await >>= maybe (return ()) push
       where
         push (position, token) =


### PR DESCRIPTION
Using xml-conduit to parse some larger XML files I've noticed progressively increasing memory use and slowing. For a 2.5MB file I produced the following heap profile:
![Original heap profile](https://f.cloud.github.com/assets/798147/769266/350e98fa-e8b1-11e2-9c06-4b82eb44a425.png)

I managed to track the space leak down to `toEventC` and `tokenToEvent` and I believe the attached patch is the minimal change necessary to avoid the leak. With the change the heap profile for the same XML file now appears as follows:
![Improved heap profile](https://f.cloud.github.com/assets/798147/769312/2bd6e41c-e8b2-11e2-9887-ffa92791b651.png)
