### PR TITLE
Add NFData instances for URI and URIAuth

### DIFF
--- a/uri-conduit/Network/URI/Conduit.hs
+++ b/uri-conduit/Network/URI/Conduit.hs
@@ -38,6 +38,7 @@ import Control.Failure (Failure (..))
 import Control.Exception (Exception)
 import Data.Typeable (Typeable)
 import Control.Monad.Trans.Class (lift)
+import Control.DeepSeq (NFData(rnf))
 
 data URI = URI
     { uriScheme :: Text
@@ -48,12 +49,19 @@ data URI = URI
     }
     deriving (Show, Eq, Ord)
 
+instance NFData URI where
+  rnf (URI a b c d e) = rnf a `seq` rnf b `seq` rnf c `seq`
+                        rnf d `seq` rnf e `seq` ()
+
 data URIAuth = URIAuth
     { uriUserInfo :: Text
     , uriRegName :: Text
     , uriPort :: Text
     }
     deriving (Show, Eq, Ord)
+
+instance NFData URIAuth where
+  rnf (URIAuth a b c) = rnf a `seq` rnf b `seq` rnf c `seq` ()
 
 parseURI :: Failure URIException m => Text -> m URI
 parseURI t = maybe (failure $ InvalidURI t) (return . fromNetworkURI) $ N.parseURI $ unpack t

--- a/uri-conduit/uri-conduit.cabal
+++ b/uri-conduit/uri-conduit.cabal
@@ -25,3 +25,4 @@ Library
                      , monad-control            >= 0.3        && < 0.4
                      , system-filepath          >= 0.4.3      && < 0.5
                      , system-fileio            >= 0.3.3      && < 0.4
+                     , deepseq                  >= 1.1.0.0


### PR DESCRIPTION
These `NFData` instances are required to avoid orphan instances when you need to control memory leaks using `deepSeq`, `force`, etc., and one of your data types happens to include a `URI`.

This change creates a dependency on the deepseq library. That is quite safe, because deepseq is bundled with GHC. I omitted the upper bound on the dependency, because the library is extremely stable. The API of the `NFData` type class, which is all we are using, has not changed for almost four years. Since then, all version bumps of deepseq have only involved ancillary functions, not the type class itself.
