### PR TITLE
Added NFData instances in Text.XML.

### DIFF
--- a/xml-conduit/Text/XML.hs
+++ b/xml-conduit/Text/XML.hs
@@ -81,6 +81,7 @@ import Data.XML.Types
     )
 import Data.Typeable (Typeable)
 import Data.Data (Data)
+import Control.DeepSeq(NFData(rnf))
 import Data.Text (Text)
 import qualified Text.XML.Stream.Parse as P
 import qualified Text.XML.Unresolved as D
@@ -125,6 +126,9 @@ data Document = Document
     }
   deriving (Show, Eq, Typeable, Data)
 
+instance NFData Document where
+  rnf (Document a b c) = rnf a `seq` rnf b `seq` rnf c `seq` ()
+
 data Node
     = NodeElement Element
     | NodeInstruction Instruction
@@ -132,12 +136,21 @@ data Node
     | NodeComment Text
   deriving (Show, Eq, Ord, Typeable, Data)
 
+instance NFData Node where
+  rnf (NodeElement e) = rnf e `seq` ()
+  rnf (NodeInstruction i) = rnf i `seq` ()
+  rnf (NodeContent t) = rnf t `seq` ()
+  rnf (NodeComment t) = rnf t `seq` ()
+
 data Element = Element
     { elementName :: Name
     , elementAttributes :: Map.Map Name Text
     , elementNodes :: [Node]
     }
   deriving (Show, Eq, Ord, Typeable, Data)
+
+instance NFData Element where
+  rnf (Element a b c) = rnf a `seq` rnf b `seq` rnf c `seq` ()
 
 {-
 readFile :: FilePath -> ParseSettings -> IO (Either SomeException Document)

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -35,7 +35,7 @@ library
                    , bytestring                >= 0.9
                    , text                      >= 0.7      && < 0.12
                    , containers                >= 0.2
-                   , xml-types                 >= 0.3.3    && < 0.4
+                   , xml-types                 >= 0.3.4    && < 0.4
                    , attoparsec                >= 0.10
                    , blaze-builder             >= 0.2      && < 0.4
                    , transformers              >= 0.2      && < 0.4
@@ -45,6 +45,7 @@ library
                    , monad-control             >= 0.3      && < 0.4
                    , blaze-markup              >= 0.5
                    , blaze-html                >= 0.5
+                   , deepseq                   >= 1.1.0.0
     exposed-modules: Text.XML.Stream.Parse
                      Text.XML.Stream.Render
                      Text.XML.Unresolved


### PR DESCRIPTION
Now that John added `NFData` instances to the types in `xml-types`, we can also add `NFData` instances to the local `Document`, `Node`, and `Element` types in `xml-conduit`. Thanks.
