### PR TITLE
Fixed types in xml-conduit sample

### DIFF
--- a/xml-conduit/parser-sample.hs
+++ b/xml-conduit/parser-sample.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 import Control.Monad.Trans.Resource
-import Data.Conduit (Sink, ($$))
+import Data.Conduit (Consumer, Sink, ($$))
 import Data.Text (Text, unpack)
 import Data.XML.Types (Event)
 import Text.XML.Stream.Parse
@@ -8,12 +8,12 @@ import Text.XML.Stream.Parse
 data Person = Person Int Text
     deriving Show
 
-parsePerson :: ResourceThrow m => Sink Event m (Maybe Person)
+parsePerson :: MonadThrow m => Consumer Event m (Maybe Person)
 parsePerson = tagName "person" (requireAttr "age") $ \age -> do
     name <- content
     return $ Person (read $ unpack age) name
 
-parsePeople :: Sink Event IO (Maybe [Person])
+parsePeople :: MonadThrow m => Sink Event m (Maybe [Person])
 parsePeople = tagNoAttr "people" $ many parsePerson
 
 main :: IO ()


### PR DESCRIPTION
I was not able to get the parser-sample.hs code to work. I made these changes and it works. I think this might be because parser-sample.hs was written against an older version of the library. 
