### PR TITLE
Allow for other text encodings besides UTF8

### DIFF
--- a/html-conduit/html-conduit.cabal
+++ b/html-conduit/html-conduit.cabal
@@ -1,5 +1,5 @@
 Name:                html-conduit
-Version:             1.1.0.4
+Version:             1.1.1.0
 Synopsis:            Parse HTML documents using xml-conduit datatypes.
 Description:         This package uses tagstream-conduit for its parser. It automatically balances mismatched tags, so that there shouldn't be any parse failures. It does not handle a full HTML document rendering, such as adding missing html and head tags.
 Homepage:            https://github.com/snoyberg/xml


### PR DESCRIPTION
Current version of html-conduit assumes utf8 encoding.
I've added a set of _with functions to allow other encodings from Data.Text.Encoding.

This still suffers from the following problems:
- Data.Text.Encoding only really supports UTF variants and Latin1 (my particular use case)
- Untested with Data.Text.ICU.Convert (but it should work)
- What would really be great would be to decode the head, find the enconding from the 
  `<meta charset="???">` field, and then apply it when decoding everything.

Perhaps when I have some more time.
Cheers
