### PR TITLE
xml-conduit: relax transformer upper bounds of cabal constraints

### DIFF
--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -39,7 +39,7 @@ library
                    , xml-types                 >= 0.3.4    && < 0.4
                    , attoparsec                >= 0.10
                    , blaze-builder             >= 0.2      && < 0.4
-                   , transformers              >= 0.2      && < 0.4
+                   , transformers              >= 0.2      && < 0.5
                    , data-default
                    , system-filepath           >= 0.4      && < 0.5
                    , monad-control             >= 0.3      && < 0.4


### PR DESCRIPTION
xml-conduit's upper bounds of cabal constraints relaxed as follows:

``` log
< 0.4 ->
< 0.5
    ^
```

`resourcet-1.1.2.2` relaxes cabal constraint `transformers < 0.4 → < 0.5.`
`mtl-2.2.x` requires `transformers == 0.4.*`
And transformers-0.4.x have been released.

 So, please relax xml-conduit cabal constraints. It seems to be inconvenience constraints....
