### PR TITLE
Rewrite some parser functions using point-free style & base functions

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -551,7 +551,7 @@ tag checkName attrParser f = do
                 Nothing -> return Nothing
         _ -> return Nothing
   where
-    -- | Drop Events until we encount a non-whitespace element
+    -- Drop Events until we encount a non-whitespace element
     dropWS = do
         x <- CL.peek
         let isWS =


### PR DESCRIPTION
I'm currently trying to solve this issue: http://stackoverflow.com/q/24336541/2597135
by implementing a function to ignore subtrees. While trying to understand the stream parser sufficiently to do so, I encountered some functions which I think can be rewritten more easily, e.g.

``` haskell
content :: MonadThrow m => Consumer Event m Text
content = do
    x <- contentMaybe
    case x of
        Nothing -> return T.empty
        Just y -> return y
```

which can be rewritten as `content = fromMaybe T.empty <$> contentMaybe`

I'm not sure if there is any specific constraint that really old base libraries need to be supported, but if there is not, I think the new implementations are overall easier to read.

Please feel free to comment in case you don't like this kind of change.
