### PR TITLE
Stream parser: Simplified implementations using either & maybe

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -210,9 +210,8 @@ detectUtf =
     conduit front = await >>= maybe (return ()) (push front)
 
     push front bss =
-        case getEncoding front bss of
-            Left x -> conduit x
-            Right (bss', continue) -> leftover bss' >> continue
+        either conduit (\(bss', continue) -> leftover bss' >> continue)
+               (getEncoding front bss)
 
     getEncoding front bs'
         | S.length bs < 4 =


### PR DESCRIPTION
Using `either` and `maybe` I was able to remove explicit case statements from some functions. I think this significantly increases readability in mosts cases. I think the library should use standard library functions wherever possible.

This is essentially a byproduct of my attempt to extend xml-conduit by functions allowing to ignore subtrees (another pull request will hopefully be finished soon).
