### PR TITLE
Add language pragma FlexibleContexts for GHC 7.10.

### DIFF
--- a/xml-hamlet/Text/Hamlet/XMLParse.hs
+++ b/xml-hamlet/Text/Hamlet/XMLParse.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP #-}
 module Text.Hamlet.XMLParse
     ( Result (..)


### PR DESCRIPTION
GHC 7.10 RC2 issues the following error when installing xml-hamlet 0.4.0.9:
```
Text/Hamlet/XMLParse.hs:167:5:
    Non type-variable argument
      in the constraint: Text.Parsec.Prim.Stream s m Char
    (Use FlexibleContexts to permit this)
    When checking that ‘contentReg’ has the inferred type
      contentReg :: forall s u (m :: * -> *).
                    Text.Parsec.Prim.Stream s m Char =>
                    ContentRule -> Text.Parsec.Prim.ParsecT s u m Content
```
The easiest remedy is to add the `FlexibleContexts` language pragma as suggested in the error message.
This change is backward compatible - GHC 7.8.4 compiles the modified version without problem.