### PR TITLE
'parseText' becomes 'parseText'/'parseTextPos', depending on the output type

### DIFF
--- a/xml-conduit/Text/XML.hs
+++ b/xml-conduit/Text/XML.hs
@@ -270,7 +270,7 @@ parseText_ ps = either throw id . parseText ps
 sinkTextDoc :: MonadThrow m
             => ParseSettings
             -> Consumer Text m Document
-sinkTextDoc ps = P.parseText ps =$= fromEvents
+sinkTextDoc ps = P.parseTextPos ps =$= fromEvents
 
 fromEvents :: MonadThrow m => Consumer P.EventPos m Document
 fromEvents = do

--- a/xml-conduit/Text/XML/Unresolved.hs
+++ b/xml-conduit/Text/XML/Unresolved.hs
@@ -262,4 +262,4 @@ parseText_ ps = either throw id . parseText ps
 sinkTextDoc :: MonadThrow m
             => ParseSettings
             -> Consumer Text m Document
-sinkTextDoc ps = P.parseText ps =$= fromEvents
+sinkTextDoc ps = P.parseTextPos ps =$= fromEvents


### PR DESCRIPTION
This is consistent with the existing `parseBytes`/`parseBytesPos`.
However, this is a backward-incompatible change...