### PR TITLE
Open up Cursor datatype

### DIFF
--- a/xml-conduit/Text/XML/Cursor/Generic.hs
+++ b/xml-conduit/Text/XML/Cursor/Generic.hs
@@ -1,7 +1,7 @@
 -- | Generalized cursors to be applied to different nodes.
 module Text.XML.Cursor.Generic
     ( -- * Core
-      Cursor
+      Cursor(..)
     , Axis
     , toCursor
     , node


### PR DESCRIPTION
In order to allow for custom (less verbose) pretty printers of a cursor, could this datatype constructors be exported?
Thanks