### PR TITLE
Add functions to ignore subtrees & result-streaming (yield) parsers - cont.

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -678,8 +678,24 @@ ignoreAnyTagName :: MonadThrow m
 ignoreAnyTagName names = ignoreTag (`elem` names)
 
 -- | Like 'ignoreTag', but matches all tag name.
+--
+--   > ignoreAllTags = ignoreTag (const True)
 ignoreAllTags :: MonadThrow m => ConduitM Event o m (Maybe ())
 ignoreAllTags = ignoreTag $ const True
+
+-- | Ignore an empty tag, its attributes and its children subtree recursively.
+--   This functions returns 'Just' if the tag matched.
+ignoreTree :: MonadThrow m
+          => (Name -> Bool) -- ^ The predicate name to match to
+          -> ConduitM Event o m (Maybe ())
+ignoreTree namePred = tagPredicateIgnoreAttrs namePred ignoreAllTrees
+
+-- | Like 'ignoreAllTags', but ignores entire subtrees.
+--
+--   > ignoreAllTrees = ignoreTree (const True)
+ignoreAllTrees :: MonadThrow m => ConduitM Event o m (Maybe ())
+ignoreAllTrees = ignoreTree $ const True
+
 
 -- | Get the value of the first parser which returns 'Just'. If no parsers
 -- succeed (i.e., return @Just@), this function returns 'Nothing'.

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -693,12 +693,18 @@ ignoreTree :: MonadThrow m
 ignoreTree namePred =
     tagPredicateIgnoreAttrs namePred (const () <$> many ignoreAllTrees)
 
+-- | Like 'ignoreTagName', but also ignores non-empty tabs
+ignoreTreeName :: MonadThrow m
+               => Name
+               -> ConduitM Event o m (Maybe ())
+ignoreTreeName name =
+    ignoreTree (== name)
+
 -- | Like 'ignoreAllTags', but ignores entire subtrees.
 --
 --   > ignoreAllTrees = ignoreTree (const True)
 ignoreAllTrees :: MonadThrow m => ConduitM Event o m (Maybe ())
 ignoreAllTrees = ignoreTree $ const True
-
 
 -- | Get the value of the first parser which returns 'Just'. If no parsers
 -- succeed (i.e., return @Just@), this function returns 'Nothing'.

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -70,6 +70,7 @@ module Text.XML.Stream.Parse
     , tagName
     , tagNoAttr
     , tagIgnoreAttrs
+    , tagPredicateIgnoreAttrs
     , content
     , contentMaybe
       -- * Attribute parsing
@@ -637,12 +638,21 @@ tagNoAttr :: MonadThrow m
           -> CI.ConduitM Event o m (Maybe a)
 tagNoAttr name f = tagName name (return ()) $ const f
 
+
 -- | A further simplified tag parser, which ignores all attributes, if any exists
 tagIgnoreAttrs :: MonadThrow m
                => Name -- ^ The name this parser matches to
                -> CI.ConduitM Event o m a -- ^ Handler function to handle the children of the matched tag
                -> CI.ConduitM Event o m (Maybe a)
 tagIgnoreAttrs name f = tagName name ignoreAttrs $ const f
+
+-- | A further simplified tag parser, which ignores all attributes, if any exists
+tagPredicateIgnoreAttrs :: MonadThrow m
+                        => (Name -> Bool) -- ^ The name predicate this parser matches to
+                        -> CI.ConduitM Event o m a -- ^ Handler function to handle the children of the matched tag
+                        -> CI.ConduitM Event o m (Maybe a)
+tagPredicateIgnoreAttrs namePred f = tagPredicate namePred ignoreAttrs $ const f
+
 
 -- | Get the value of the first parser which returns 'Just'. If no parsers
 -- succeed (i.e., return @Just@), this function returns 'Nothing'.

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -71,11 +71,13 @@ module Text.XML.Stream.Parse
     , tagNoAttr
     , tagIgnoreAttrs
     , tagPredicateIgnoreAttrs
+    , content
+    , contentMaybe
+      -- * Ignoring tags/trees
     , ignoreTag
     , ignoreTagName
     , ignoreAnyTagName
-    , content
-    , contentMaybe
+    , ignoreTree
       -- * Attribute parsing
     , AttrParser
     , requireAttr
@@ -688,7 +690,8 @@ ignoreAllTags = ignoreTag $ const True
 ignoreTree :: MonadThrow m
           => (Name -> Bool) -- ^ The predicate name to match to
           -> ConduitM Event o m (Maybe ())
-ignoreTree namePred = tagPredicateIgnoreAttrs namePred ignoreAllTrees
+ignoreTree namePred =
+    tagPredicateIgnoreAttrs namePred (fromMaybe () <$> ignoreAllTrees)
 
 -- | Like 'ignoreAllTags', but ignores entire subtrees.
 --

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -677,6 +677,10 @@ ignoreAnyTagName :: MonadThrow m
                  -> ConduitM Event o m (Maybe ())
 ignoreAnyTagName names = ignoreTag (`elem` names)
 
+-- | Like 'ignoreTag', but matches all tag name.
+ignoreAllTags :: MonadThrow m => ConduitM Event o m (Maybe ())
+ignoreAllTags = ignoreTag $ const True
+
 -- | Get the value of the first parser which returns 'Just'. If no parsers
 -- succeed (i.e., return @Just@), this function returns 'Nothing'.
 --

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -71,6 +71,8 @@ module Text.XML.Stream.Parse
     , tagNoAttr
     , tagIgnoreAttrs
     , tagPredicateIgnoreAttrs
+    , ignoreTag
+    , ignoreTagName
     , content
     , contentMaybe
       -- * Attribute parsing
@@ -653,6 +655,20 @@ tagPredicateIgnoreAttrs :: MonadThrow m
                         -> CI.ConduitM Event o m (Maybe a)
 tagPredicateIgnoreAttrs namePred f = tagPredicate namePred ignoreAttrs $ const f
 
+-- | Ignore an empty tag and all of its attributes by predicate.
+--   This does not ignore the tag recursively
+--   (i.e. it assumes there are no child elements).
+--   This functions returns 'Just' if the tag matched.
+ignoreTag :: MonadThrow m
+          => (Name -> Bool) -- ^ The predicate name to match to
+          -> ConduitM Event o m (Maybe ())
+ignoreTag namePred = tagPredicateIgnoreAttrs namePred (return ())
+
+-- | Like 'ignoreTag', but matches an exact name
+ignoreTagName :: MonadThrow m
+              => Name -- ^ The name to match to
+              -> ConduitM Event o m (Maybe ())
+ignoreTagName name = ignoreTag (== name)
 
 -- | Get the value of the first parser which returns 'Just'. If no parsers
 -- succeed (i.e., return @Just@), this function returns 'Nothing'.

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -73,6 +73,7 @@ module Text.XML.Stream.Parse
     , tagPredicateIgnoreAttrs
     , ignoreTag
     , ignoreTagName
+    , ignoreAnyTagName
     , content
     , contentMaybe
       -- * Attribute parsing
@@ -669,6 +670,12 @@ ignoreTagName :: MonadThrow m
               => Name -- ^ The name to match to
               -> ConduitM Event o m (Maybe ())
 ignoreTagName name = ignoreTag (== name)
+
+-- | Like 'ignoreTagName', but matches any name from a list of names.
+ignoreAnyTagName :: MonadThrow m
+                 => [Name] -- ^ The name to match to
+                 -> ConduitM Event o m (Maybe ())
+ignoreAnyTagName names = ignoreTag (`elem` names)
 
 -- | Get the value of the first parser which returns 'Just'. If no parsers
 -- succeed (i.e., return @Just@), this function returns 'Nothing'.

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -69,6 +69,7 @@ module Text.XML.Stream.Parse
     , tagPredicate
     , tagName
     , tagNoAttr
+    , tagIgnoreAttrs
     , content
     , contentMaybe
       -- * Attribute parsing
@@ -634,6 +635,13 @@ tagNoAttr :: MonadThrow m
           -> CI.ConduitM Event o m a -- ^ Handler function to handle the children of the matched tag
           -> CI.ConduitM Event o m (Maybe a)
 tagNoAttr name f = tagName name (return ()) $ const f
+
+-- | A further simplified tag parser, which ignores all attributes, if any exists
+tagIgnoreAttrs :: MonadThrow m
+               => Name -- ^ The name this parser matches to
+               -> CI.ConduitM Event o m a -- ^ Handler function to handle the children of the matched tag
+               -> CI.ConduitM Event o m (Maybe a)
+tagIgnoreAttrs name f = tagName name ignoreAttrs $ const f
 
 -- | Get the value of the first parser which returns 'Just'. If no parsers
 -- succeed (i.e., return @Just@), this function returns 'Nothing'.

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -107,6 +107,8 @@ module Text.XML.Stream.Parse
     , ignoreTagName
     , ignoreAnyTagName
     , ignoreTree
+    , ignoreTreeName
+    , ignoreAllTrees
       -- * Attribute parsing
     , AttrParser
     , requireAttr
@@ -900,11 +902,11 @@ manyIgnoreYield :: MonadThrow m
                 => ConduitM Event b m (Maybe b) -- ^ Consuming parser that generates the result stream
                 -> Consumer Event m (Maybe ()) -- ^ Ignore parser that consumes elements to be ignored
                 -> Conduit Event m b
-manyIgnoreYield consumer ignore =
+manyIgnoreYield consumer ignoreParser =
     loop
   where
     loop = consumer >>= maybe onFail (\x -> yield x >> loop)
-    onFail = ignore >>= maybe (return ()) (const loop)
+    onFail = ignoreParser >>= maybe (return ()) (const loop)
 
 -- | Like @many'@, but uses 'yield' so the result list can be streamed
 --   to downstream conduits without waiting for 'manyYield' to finished

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -691,7 +691,7 @@ ignoreTree :: MonadThrow m
           => (Name -> Bool) -- ^ The predicate name to match to
           -> ConduitM Event o m (Maybe ())
 ignoreTree namePred =
-    tagPredicateIgnoreAttrs namePred (fromMaybe () <$> ignoreAllTrees)
+    tagPredicateIgnoreAttrs namePred (const () <$> many ignoreAllTrees)
 
 -- | Like 'ignoreAllTags', but ignores entire subtrees.
 --

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -106,8 +106,10 @@ module Text.XML.Stream.Parse
     , ignoreTag
     , ignoreTagName
     , ignoreAnyTagName
+    , ignoreAllTags
     , ignoreTree
     , ignoreTreeName
+    , ignoreAnyTreeName
     , ignoreAllTrees
       -- * Attribute parsing
     , AttrParser
@@ -733,6 +735,13 @@ ignoreTreeName :: MonadThrow m
                => Name
                -> ConduitM Event o m (Maybe ())
 ignoreTreeName name = ignoreTree (== name)
+
+-- | Like 'ignoreTagName', but matches any name from a list of names.
+ignoreAnyTreeName :: MonadThrow m
+                 => [Name] -- ^ The name to match to
+                 -> ConduitM Event o m (Maybe ())
+ignoreAnyTreeName names = ignoreTree (`elem` names)
+
 
 -- | Like 'ignoreAllTags', but ignores entire subtrees.
 --

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -123,6 +123,7 @@ module Text.XML.Stream.Parse
     , choose
     , many
     , manyIgnore
+    , many'
     , force
       -- * Streaming combinators
     , manyYield
@@ -894,6 +895,13 @@ manyIgnore i ignored =
     -- onFail is called if the main parser fails
     onFail front =
         ignored >>= maybe (return $ front []) (const $ go front)
+
+-- | Like @many@, but any tags the consumer doesn't match on
+--   are silently ignored. 
+many' :: MonadThrow m
+           => Consumer Event m (Maybe a)
+           -> Consumer Event m [a]
+many' consumer = manyIgnore consumer ignoreAllTrees
 
 -- | Like 'many', but uses 'yield' so the result list can be streamed
 --   to downstream conduits without waiting for 'manyYield' to finished

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -396,7 +396,7 @@ parseToken de = (char '<' >> parseLt) <|> TokenContent <$> parseContent de False
         char' '-'
         char' '-'
         c <- T.pack <$> manyTill anyChar (string "-->") -- FIXME use takeWhile instead
-        return $ TokenComment c
+        return $ TokenComment c 
     parseCdata = do
         _ <- string "[CDATA["
         t <- T.pack <$> manyTill anyChar (string "]]>") -- FIXME use takeWhile instead
@@ -683,14 +683,14 @@ tagNoAttr :: MonadThrow m
 tagNoAttr name f = tagName name (return ()) $ const f
 
 
--- | A further simplified tag parser, which ignores all attributes, if any exists
+-- | A further simplified tag parser, which ignores all attributes, if any exist
 tagIgnoreAttrs :: MonadThrow m
                => Name -- ^ The name this parser matches to
                -> CI.ConduitM Event o m a -- ^ Handler function to handle the children of the matched tag
                -> CI.ConduitM Event o m (Maybe a)
 tagIgnoreAttrs name f = tagName name ignoreAttrs $ const f
 
--- | A further simplified tag parser, which ignores all attributes, if any exists
+-- | A further simplified tag parser, which ignores all attributes, if any exist
 tagPredicateIgnoreAttrs :: MonadThrow m
                         => (Name -> Bool) -- ^ The name predicate this parser matches to
                         -> CI.ConduitM Event o m a -- ^ Handler function to handle the children of the matched tag

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -20,6 +20,7 @@ import           Text.XML.Stream.Parse        (def)
 import Text.XML.Cursor ((&/), (&//), (&.//), ($|), ($/), ($//), ($.//))
 import Data.Text(Text)
 import Control.Monad
+import Control.Applicative ((<$>))
 import Control.Monad.Trans.Class (lift)
 import qualified Data.Text as T
 import qualified Data.Set as Set
@@ -40,6 +41,7 @@ main = hspec $ do
         it "has working choose function" testChoose
         it "has working many function" testMany
         it "has working many' function" testMany'
+        it "has working manyYield function" testManyYield
         it "has working orE" testOrE
         it "is idempotent to parse and pretty render a document" documentParsePrettyRender
         it "ignores the BOM" parseIgnoreBOM
@@ -163,6 +165,28 @@ testChoose = C.runResourceT $ P.parseLBS def input C.$$ do
         [ "<?xml version='1.0'?>"
         , "<!DOCTYPE foo []>\n"
         , "<hello>"
+        , "<success/>"
+        , "</hello>"
+        ]
+
+testManyYield :: Assertion
+testManyYield = do
+    -- Basically the same as testMany, but consume the streamed result
+    result <- C.runResourceT $
+        P.parseLBS def input C.$$ helloParser
+        C.$= CL.consume
+    length result @?= 5
+  where
+    helloParser = void $ P.tagNoAttr "hello" $ P.manyYield successParser
+    successParser = P.tagNoAttr "success" $ return ()
+    input = L.concat
+        [ "<?xml version='1.0'?>"
+        , "<!DOCTYPE foo []>\n"
+        , "<hello>"
+        , "<success/>"
+        , "<success/>"
+        , "<success/>"
+        , "<success/>"
         , "<success/>"
         , "</hello>"
         ]

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -39,6 +39,7 @@ main = hspec $ do
         it "has valid parser combinators" combinators
         it "has working choose function" testChoose
         it "has working many function" testMany
+        it "has working many' function" testMany'
         it "has working orE" testOrE
         it "is idempotent to parse and pretty render a document" documentParsePrettyRender
         it "ignores the BOM" parseIgnoreBOM
@@ -180,6 +181,26 @@ testMany = C.runResourceT $ P.parseLBS def input C.$$ do
         , "<success/>"
         , "<success/>"
         , "<success/>"
+        , "<success/>"
+        , "</hello>"
+        ]
+
+testMany' :: Assertion
+testMany' = C.runResourceT $ P.parseLBS def input C.$$ do
+    P.force "need hello" $ P.tagNoAttr "hello" $ do
+        x <- P.many' $ P.tagNoAttr "success" $ return ()
+        liftIO $ length x @?= 5
+  where
+    input = L.concat
+        [ "<?xml version='1.0'?>"
+        , "<!DOCTYPE foo []>\n"
+        , "<hello>"
+        , "<success/>"
+        , "<success/>"
+        , "<success/>"
+        , "<foobar/>"
+        , "<success/>"
+        , "<foo><bar attr=\"1\">some content</bar></foo>"
         , "<success/>"
         , "</hello>"
         ]


### PR DESCRIPTION
Continuation of #40 