### PR TITLE
Escaping CDATA closing tag in CDATA

### DIFF
--- a/xml-conduit/Text/XML.hs
+++ b/xml-conduit/Text/XML.hs
@@ -62,6 +62,7 @@ module Text.XML
     , R.rsPretty
     , R.rsNamespaces
     , R.rsAttrOrder
+    , R.rsUseCDATA
     , R.orderAttrs
       -- * Conversion
     , toXMLDocument

--- a/xml-conduit/Text/XML/Stream/Token.hs
+++ b/xml-conduit/Text/XML/Stream/Token.hs
@@ -68,9 +68,9 @@ tokenToBuilder (TokenEndElement name) = mconcat
     , fromByteString ">"
     ]
 tokenToBuilder (TokenContent c) = contentToText c
-tokenToBuilder (TokenCDATA t) =
+tokenToBuilder (TokenCDATA t) = 
     copyByteString "<![CDATA["
-    `mappend` fromText t
+    `mappend` escCDATA t
     `mappend` copyByteString "]]>"
 tokenToBuilder (TokenComment t) = mconcat [fromByteString "<!--", fromText t, fromByteString "-->"]
 tokenToBuilder (TokenDoctype name eid _) = mconcat
@@ -171,3 +171,23 @@ splitTName x@(TName Nothing t)
     | otherwise = TName (Just a) $ T.drop 1 b
   where
     (a, b) = T.break (== ':') t
+
+escCDATA :: Text -> Builder
+escCDATA s = case findCDATAEnd s of
+    Left cs -> copyByteString  "]]]]><![CDATA[>" `mappend` escCDATA cs
+    Right (Just (c, cs)) -> BC8.fromChar c `mappend` escCDATA cs
+    Right Nothing -> mempty
+  where
+      findCDATAEnd :: Text -> Either Text (Maybe (Char, Text))
+      findCDATAEnd s = 
+          let s' = T.uncons s
+              r = do
+                (c0, cs0) <- s'
+                (c1, cs1) <- T.uncons cs0
+                (c2, cs2) <- T.uncons cs1
+                case (c0, c1, c2) of
+                  (']', ']', '>') -> return cs2
+                  _ -> Nothing
+          in case r of
+              Just cs -> Left cs
+              Nothing -> Right s' 

--- a/xml-conduit/Text/XML/Stream/Token.hs
+++ b/xml-conduit/Text/XML/Stream/Token.hs
@@ -171,23 +171,6 @@ splitTName x@(TName Nothing t)
     | otherwise = TName (Just a) $ T.drop 1 b
   where
     (a, b) = T.break (== ':') t
-
+    
 escCDATA :: Text -> Builder
-escCDATA s = case findCDATAEnd s of
-    Left cs -> copyByteString  "]]]]><![CDATA[>" `mappend` escCDATA cs
-    Right (Just (c, cs)) -> BC8.fromChar c `mappend` escCDATA cs
-    Right Nothing -> mempty
-  where
-      findCDATAEnd :: Text -> Either Text (Maybe (Char, Text))
-      findCDATAEnd s = 
-          let s' = T.uncons s
-              r = do
-                (c0, cs0) <- s'
-                (c1, cs1) <- T.uncons cs0
-                (c2, cs2) <- T.uncons cs1
-                case (c0, c1, c2) of
-                  (']', ']', '>') -> return cs2
-                  _ -> Nothing
-          in case r of
-              Just cs -> Left cs
-              Nothing -> Right s' 
+escCDATA s = fromText (T.replace "]]>" "]]]]><![CDATA[>" s)

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -95,6 +95,7 @@ main = hspec $ do
     it "retains namespaces when asked" caseRetainNamespaces
     it "handles iso-8859-1" caseIso8859_1
     it "renders CDATA when asked" caseRenderCDATA 
+    it "escapes CDATA closing tag in CDATA" caseEscapesCDATA
 
 documentParseRender :: IO ()
 documentParseRender =
@@ -631,3 +632,13 @@ caseRenderCDATA = do
         withCDATA = Res.renderLBS (def { Res.rsUseCDATA = const True }) doc
     withCDATA `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a><![CDATA[www.google.com]]></a>"
     withoutCDATA `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>www.google.com</a>"
+
+caseEscapesCDATA :: Assertion
+caseEscapesCDATA = do
+    let doc = Res.Document (Res.Prologue [] Nothing [])
+                (Res.Element "a" Map.empty
+                    [ Res.NodeContent "]]>"
+                    ])
+                []
+        result = Res.renderLBS (def { Res.rsUseCDATA = const True }) doc
+    result `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a><![CDATA[]]]]><![CDATA[>]]></a>"

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -94,6 +94,7 @@ main = hspec $ do
     it "parsing CDATA" caseParseCdata
     it "retains namespaces when asked" caseRetainNamespaces
     it "handles iso-8859-1" caseIso8859_1
+    it "renders CDATA when asked" caseRenderCDATA 
 
 documentParseRender :: IO ()
 documentParseRender =
@@ -618,3 +619,15 @@ caseIso8859_1 = do
             Map.empty
             [Res.NodeContent "\232"])
         []
+
+caseRenderCDATA :: Assertion
+caseRenderCDATA = do
+    let doc = Res.Document (Res.Prologue [] Nothing [])
+                (Res.Element "a" Map.empty
+                    [ Res.NodeContent "www.google.com"
+                    ])
+                []
+        withoutCDATA = Res.renderLBS def doc
+        withCDATA = Res.renderLBS (def { Res.rsUseCDATA = const True }) doc
+    withCDATA `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a><![CDATA[www.google.com]]></a>"
+    withoutCDATA `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a>www.google.com</a>"


### PR DESCRIPTION
Handles CDATA closing tag (`]]>`) while rendering CDATA in the same way as the `Text.XML.Light` package does.