### PR TITLE
Only skip XML white-space when scanning for tag-start.

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -160,7 +160,6 @@ import           Control.Monad                (ap, guard, liftM, void)
 import           Control.Monad.Trans.Class    (lift)
 import qualified Data.ByteString              as S
 import qualified Data.ByteString.Lazy         as L
-import           Data.Char                    (isSpace)
 import           Data.Conduit
 import           Data.Conduit.Binary          (sourceFile)
 import qualified Data.Conduit.Internal        as CI
@@ -683,7 +682,7 @@ tag checkName attrParser f = do
                     Just EventBeginElement{} -> False
                     Just EventEndElement{} -> False
                     Just (EventContent (ContentText t))
-                        | T.all isSpace t -> True
+                        | T.all isXMLSpace t -> True
                         | otherwise -> False
                     Just (EventContent ContentEntity{}) -> False
                     Just EventComment{} -> True

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -141,7 +141,7 @@ combinators = C.runResourceT $ P.parseLBS def input C.$$ do
         P.force "need child2" $ P.tagNoAttr "child2" $ return ()
         P.force "need child3" $ P.tagNoAttr "child3" $ do
             x <- P.contentMaybe
-            liftIO $ x @?= Just "combine <all> &content"
+            liftIO $ x @?= Just "\160combine <all> &content"
   where
     input = L.concat
         [ "<?xml version='1.0'?>"
@@ -151,7 +151,7 @@ combinators = C.runResourceT $ P.parseLBS def input C.$$ do
         , "<child1 xmlns='mynamespace'/>"
         , "<!-- this should be ignored -->"
         , "<child2>   </child2>"
-        , "<child3>combine &lt;all&gt; <![CDATA[&content]]></child3>\n"
+        , "<child3>&#160;combine &lt;all&gt; <![CDATA[&content]]></child3>\n"
         , "</hello>"
         ]
 


### PR DESCRIPTION
~~I failed to replicate my issue (annoyingly). But I note it seemed worthwhile to include a test for this behaviour anyway. Feel free to ignore, but you may wish to include this.~~

This PR fixes an issue with back-tracking when one has to match either an XML element or text content.