### PR TITLE
Whitespace sensitive tokenisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
 - ARGS=""
 - ARGS="--resolver lts-2"
 - ARGS="--resolver lts-3"
+- ARGS="--resolver lts-4"
+- ARGS="--resolver lts-5"
 - ARGS="--resolver lts"
 - ARGS="--resolver nightly"
 

--- a/html-conduit/test/main.hs
+++ b/html-conduit/test/main.hs
@@ -36,9 +36,9 @@ main = hspec $ do
         it "multiple root elements" $
             X.parseLBS_ X.def "<html><foo><bar>baz&amp;foobar;</bar></foo><foo/></html>" @=?
             H.parseLBS        "<foo><bar>baz&foobar;</foo><foo>"
-        it "doesn't strip whitespace" $
-            X.parseLBS_ X.def "<foo>  hello</foo>" @=?
-            H.parseLBS        "<foo>  hello</foo>"
+        it "doesn't strip whitespace" $ do
+            let input = "<foo>  hello</foo>"
+            H.parseLBS input `shouldBe` X.parseLBS_ X.def { X.psPreserveWhiteSpace = True } input
         it "split code-points" $
             X.parseLBS_ X.def "<foo>&#xa0;</foo>" @=?
             H.parseBSChunks ["<foo>\xc2", "\xa0</foo>"]

--- a/xml-conduit/Text/XML.hs
+++ b/xml-conduit/Text/XML.hs
@@ -54,6 +54,7 @@ module Text.XML
     , ParseSettings
     , psDecodeEntities
     , P.psRetainNamespaces
+    , P.psPreserveWhiteSpace
       -- *** Entity decoding
     , P.decodeXmlEntities
     , P.decodeHtmlEntities

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -644,12 +644,15 @@ parseContent de preserveWhiteSpace breakDouble breakSingle =
         bs <- if not (T.null leading) && preserveWhiteSpace
                     then takeWhile valid <?> "valid content character"
                     else takeWhile1 valid <?> "at least one valid content character"
-        let text = leading <> bs
-        return $ ContentText text
+        le <- AT.option ""
+              $ (string "\n" <|> string "\r\n" <|> string "\r") >> return "\n"
+        return $ ContentText (leading <> bs <> le)
     valid '"' = not breakDouble
     valid '\'' = not breakSingle
     valid '&' = False -- amp
     valid '<' = False -- lt
+    valid '\r' = False -- lt
+    valid '\n' = False -- lt
     valid _  = True
 
 skipSpace :: Parser ()

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -160,7 +160,6 @@ import           Control.Monad                (ap, guard, liftM, void)
 import           Control.Monad.Trans.Class    (lift)
 import qualified Data.ByteString              as S
 import qualified Data.ByteString.Lazy         as L
-import           Data.Char                    (isSpace)
 import           Data.Conduit
 import           Data.Conduit.Binary          (sourceFile)
 import qualified Data.Conduit.Internal        as CI
@@ -683,7 +682,7 @@ tag checkName attrParser f = do
                     Just EventBeginElement{} -> False
                     Just EventEndElement{} -> False
                     Just (EventContent (ContentText t))
-                        | T.all isSpace t -> True
+                        | T.all isXMLSpace t -> True
                         | otherwise -> False
                     Just (EventContent ContentEntity{}) -> False
                     Just EventComment{} -> True

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -141,9 +141,9 @@ combinators = C.runResourceT $ P.parseLBS def input C.$$ do
         P.force "need child2" $ P.tagNoAttr "child2" $ return ()
         P.force "need child3" $ P.tagNoAttr "child3" $ do
             x <- P.contentMaybe
-            liftIO $ x @?= Just "\160combine <all> &content"
+            liftIO $ x @?= Just "\160 combine <all> &content"
   where
-    input = L.concat
+    input = L.unlines
         [ "<?xml version='1.0'?>"
         , "<!DOCTYPE foo []>\n"
         , "<hello world='true'>"
@@ -151,7 +151,7 @@ combinators = C.runResourceT $ P.parseLBS def input C.$$ do
         , "<child1 xmlns='mynamespace'/>"
         , "<!-- this should be ignored -->"
         , "<child2>   </child2>"
-        , "<child3>&#160;combine &lt;all&gt; <![CDATA[&content]]></child3>\n"
+        , "<child3>&#160; combine &lt;all&gt; <![CDATA[&content]]></child3>\n"
         , "</hello>"
         ]
 

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -141,7 +141,7 @@ combinators = C.runResourceT $ P.parseLBS def input C.$$ do
         P.force "need child2" $ P.tagNoAttr "child2" $ return ()
         P.force "need child3" $ P.tagNoAttr "child3" $ do
             x <- P.contentMaybe
-            liftIO $ x @?= Just "combine <all> &content"
+            liftIO $ x @?= Just "\160combine <all> &content"
   where
     input = L.concat
         [ "<?xml version='1.0'?>"
@@ -151,7 +151,7 @@ combinators = C.runResourceT $ P.parseLBS def input C.$$ do
         , "<child1 xmlns='mynamespace'/>"
         , "<!-- this should be ignored -->"
         , "<child2>   </child2>"
-        , "<child3>combine &lt;all&gt; <![CDATA[&content]]></child3>\n"
+        , "<child3>&#160;combine &lt;all&gt; <![CDATA[&content]]></child3>\n"
         , "</hello>"
         ]
 

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -57,6 +57,7 @@ test-suite test
                           , conduit
                           , blaze-markup
                           , resourcet
+                          , conduit-extra
 
 source-repository head
   type:     git


### PR DESCRIPTION
This is the PR referred to in #75. It improves tokenisation to handle leading XML white-space consistently. The benefit of this is that entities (such as `&x#20;` will *never* be handled by the tokenisation level as whitespace. Thus it is now possible to have content `<a>&x#20;<b/></a>` which will cause the following parser to fail:

```haskell
bInsideA = tagNoAttr "a" (tagNoAttr "b" >> return "Found")
```

which will now fail - whereas previously it would have succeeded, erroneously consuming the encoded space.

This has been updated to include configurable white-space preservation and more spec compliant tag-name parsing.