### PR TITLE
Disable ImpredicativeTypes in Text.XML.Stream.Parse

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BangPatterns       #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts   #-}
-{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE PatternGuards      #-}
 {-# LANGUAGE RankNTypes         #-}


### PR DESCRIPTION
ImpredicativeTypes hasn't been supported for years, is currently
extremely broken (especially in the up-coming GHC 8.0.1 release), and
is not necessary for this module.

Fixes #80.