### PR TITLE
Improvements for using xml-conduit for streaming XML protocols

### DIFF
--- a/xml-conduit/Text/XML/Unresolved.hs
+++ b/xml-conduit/Text/XML/Unresolved.hs
@@ -145,6 +145,7 @@ manyTries f =
 dropReturn :: Monad m => a -> ConduitM i o m a
 dropReturn x = CL.drop 1 >> return x
 
+-- | Parse a document from a stream of events.
 fromEvents :: MonadThrow m => Consumer P.EventPos m Document
 fromEvents = do
     skip EventBeginDocument
@@ -200,6 +201,7 @@ fromEvents = do
             Just epos -> lift $ monadThrow $ InvalidInlineDoctype epos
             Nothing -> lift $ monadThrow UnterminatedInlineDoctype
 
+-- | Try to parse a document element (as defined in XML) from a stream of events.
 elementFromEvents :: MonadThrow m => Consumer P.EventPos m (Maybe Element)
 elementFromEvents = goE
   where
@@ -225,6 +227,7 @@ elementFromEvents = goE
             Just (_, EventCDATA t) -> dropReturn $ Just $ NodeContent $ ContentText t
             _ -> return Nothing
 
+-- | Render a document into events.
 toEvents :: Document -> [Event]
 toEvents (Document prol root epi) =
       (EventBeginDocument :)
@@ -241,6 +244,7 @@ toEvents (Document prol root epi) =
         (:) (EventBeginDoctype name meid)
       . (:) EventEndDoctype
 
+-- | Render a document element into events.
 elementToEvents :: Element -> [Event]
 elementToEvents e = elementToEvents' e []
 


### PR DESCRIPTION
This consists of two parts:

1. Add `element{To,From}Events` which allow one to render streams from elements rather than complete documents. For example, I use this to implement an XMPP client which first sends opening `<stream>` root element (manually encoded with `[Event]`) and then lots of messages (`Element`s) inside which are sent in real time via a conduit.

2. Add `renderBuilderFlush` which allows one to control where downstream `builderToByteStringFlush` should flush message to the socket. This is required for streaming protocols where one is expected to send part of XML "document" (a "stanza" for XMPP) and then await for reply.