### PR TITLE
Clean-up + enrich XmlException + add takeAllTreesContent

### DIFF
--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.4.0
+
+* Improve XmlException definition and usage
+* Add 'takeScopedC' function
+
 ## 1.3.5
 
 * Improvements for using xml-conduit for streaming XML protocols [#85](https://github.com/snoyberg/xml/pull/85)

--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,7 +1,7 @@
 ## 1.4.0
 
 * Improve XmlException definition and usage
-* Add 'takeScopedC' function
+* Add 'takeAllTreesContent' function
 
 ## 1.3.5
 

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -767,6 +767,8 @@ tagPredicateIgnoreAttrs namePred f = tagPredicate namePred ignoreAttrs $ const f
 --
 -- >>> runResourceT $ parseLBS def "<b><c></c></b></a>text" $$ takeScopedC =$= consume
 -- Just [ EventBeginElement "b" [], EventBeginElement "c" [], EventEndElement "c", EventEndElement "b" ]
+--
+-- Since 1.4.0
 takeScopedC :: MonadThrow m => ConduitM Event Event m ()
 takeScopedC = do
   event <- await

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 import           Control.Exception            (Exception, toException)

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -1,5 +1,5 @@
 name:            xml-conduit
-version:         1.3.5
+version:         1.4.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Aristid Breitkreuz <aristidb@googlemail.com>


### PR DESCRIPTION
This pull requests has 3 parts:
- c98c086 cleans up many parts of the code, mostly thanks to hlint and stylish-haskell;
- b866f92 makes `XmlException` usage more accurate;
- e18bbe5 adds `takeScopedC` conduit, useful when you want to parse the whole content of a tag without prior knowledge of what it is composed of; I'm not satisfied with the naming though.

All tests are green.
Could you please review it ?