### PR TITLE
Change 'tag' to return Nothing, rather than throw an exception.

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -656,6 +656,7 @@ tag :: MonadThrow m
                          --   If this returns @Nothing@, the function will also return @Nothing@
     -> (a -> AttrParser b) -- ^ Given the value returned by the name checker, this function will
                            --   be used to get an @AttrParser@ appropriate for the specific tag.
+                           --   If the @AttrParser@ fails, the function will also return @Nothing@
     -> (b -> CI.ConduitM Event o m c) -- ^ Handler function to handle the attributes and children
                                       --   of a tag, given the value return from the @AttrParser@
     -> CI.ConduitM Event o m (Maybe c)
@@ -666,7 +667,7 @@ tag checkName attrParser f = do
             case checkName name of
                 Just y ->
                     case runAttrParser' (attrParser y) as of
-                        Left e -> lift $ monadThrow e
+                        Left e -> return Nothing
                         Right z -> do
                             z' <- f z
                             (a, _leftovers') <- dropWS []


### PR DESCRIPTION
This allows parsers to conditionally accept a tag, depending on it's attributes. I frequently find myself needing to decide whether to accept a tag based on it's attributes, which isn't possible with the current xml-conduit API, this simple change makes this operation trivial.

See also #60 (which already has a pull request, but I think that solution is needlessly complex).