### PR TITLE
Add 'skipMany' to skip values without needing to build an intermediat…

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -984,7 +984,7 @@ many' consumer = manyIgnore consumer ignoreAllTreesContent
 skipMany :: MonadThrow m
          => Consumer Event m (Maybe a)
          -> Consumer Event m ()
-skipMany consumer = manyIgnoreYield (return Nothing) ((() <$) <$> consumer)
+skipMany consumer = manyIgnoreYield (return Nothing) (void <$> consumer)
 
 -- | Like 'many', but uses 'yield' so the result list can be streamed
 --   to downstream conduits without waiting for 'manyYield' to finish

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -129,6 +129,7 @@ module Text.XML.Stream.Parse
     , many
     , manyIgnore
     , many'
+    , skipMany
     , force
       -- * Streaming combinators
     , manyYield
@@ -977,6 +978,13 @@ many' :: MonadThrow m
       => Consumer Event m (Maybe a)
       -> Consumer Event m [a]
 many' consumer = manyIgnore consumer ignoreAllTreesContent
+
+-- | Keep parsing elements as long as the parser returns 'Just', but throw the
+--   elements away without building an intermediate list.
+skipMany :: MonadThrow m
+         => Consumer Event m (Maybe a)
+         -> Consumer Event m ()
+skipMany consumer = manyIgnoreYield (return Nothing) ((() <$) <$> consumer)
 
 -- | Like 'many', but uses 'yield' so the result list can be streamed
 --   to downstream conduits without waiting for 'manyYield' to finish


### PR DESCRIPTION
I often find myself needing to skip over many tags while scraping messy data. Having a convenient combinator for this is nicer than repeated use of 'manyIgnoreYield (return Nothing)', although not absolutely crucial.