### PR TITLE
Fix `takeAllTreesContent` to only consume a single tag/tree.

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -1035,21 +1035,21 @@ takeAllTreesContent = do
       takeAllTreesContent
       endEvent <- await
       case endEvent of
-        Just e@EventEndDoctype -> yield e >> takeAllTreesContent
+        Just e@EventEndDoctype -> yield e
         _ -> lift $ monadThrow $ XmlException "Expected end of doctype" endEvent
     Just e@EventBeginDocument -> do
       yield e
       takeAllTreesContent
       endEvent <- await
       case endEvent of
-        Just e@EventEndDocument -> yield e >> takeAllTreesContent
+        Just e@EventEndDocument -> yield e
         _ -> lift $ monadThrow $ XmlException "Expected end of document" endEvent
     Just e@(EventBeginElement name _) -> do
       yield e
       takeAllTreesContent
       endEvent <- await
       case endEvent of
-        Just e@(EventEndElement name') | name == name' -> yield e >> takeAllTreesContent
+        Just e@(EventEndElement name') | name == name' -> yield e
         _ -> lift $ monadThrow $ InvalidEndElement name endEvent
     Just e@EventComment{} -> yield e >> takeAllTreesContent
     Just e@EventContent{} -> yield e >> takeAllTreesContent

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -1032,29 +1032,29 @@ takeAllTreesContent = do
   case event of
     Just e@EventBeginDoctype{} -> do
       yield e
-      takeAllTreesContent
+      many_ takeAllTreesContent
       endEvent <- await
       case endEvent of
         Just e@EventEndDoctype -> yield e
         _ -> lift $ monadThrow $ XmlException "Expected end of doctype" endEvent
     Just e@EventBeginDocument -> do
       yield e
-      takeAllTreesContent
+      many_ takeAllTreesContent
       endEvent <- await
       case endEvent of
         Just e@EventEndDocument -> yield e
         _ -> lift $ monadThrow $ XmlException "Expected end of document" endEvent
     Just e@(EventBeginElement name _) -> do
       yield e
-      takeAllTreesContent
+      many_ takeAllTreesContent
       endEvent <- await
       case endEvent of
         Just e@(EventEndElement name') | name == name' -> yield e
         _ -> lift $ monadThrow $ InvalidEndElement name endEvent
-    Just e@EventComment{} -> yield e >> takeAllTreesContent
-    Just e@EventContent{} -> yield e >> takeAllTreesContent
-    Just e@EventInstruction{} -> yield e >> takeAllTreesContent
-    Just e@EventCDATA{} -> yield e >> takeAllTreesContent
+    Just e@EventComment{} -> yield e
+    Just e@EventContent{} -> yield e
+    Just e@EventInstruction{} -> yield e
+    Just e@EventCDATA{} -> yield e
     Just e -> leftover e
     _ -> return ()
 


### PR DESCRIPTION
The documentation of `takeAllTreesContent` implies it consumes only a single
tag/tree, however it's implementation currently consumes every single event
remaining in the stream.

Fixes #97.