### PR TITLE
Allow omission of the XML declaration when rendering documents.

### DIFF
--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+* New render setting, `rsXMLDeclaration`; setting it to `False` omits the XML declaration.
+
 ## 1.5.0
 
 * `tag` function no longer throws an exception when attributes don't match [#93](https://github.com/snoyberg/xml/pull/93)

--- a/xml-conduit/Text/XML.hs
+++ b/xml-conduit/Text/XML.hs
@@ -63,6 +63,7 @@ module Text.XML
     , R.rsNamespaces
     , R.rsAttrOrder
     , R.rsUseCDATA
+    , R.rsXMLDeclaration
     , R.orderAttrs
       -- * Conversion
     , toXMLDocument

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -204,7 +204,7 @@ import           Text.XML.Stream.Token
 type Ents = [(Text, Text)]
 
 tokenToEvent :: ParseSettings -> Ents -> [NSLevel] -> Token -> (Ents, [NSLevel], [Event])
-tokenToEvent _ es n (TokenBeginDocument _) = (es, n, [])
+tokenToEvent _ es n (TokenXMLDeclaration _) = (es, n, [])
 tokenToEvent _ es n (TokenInstruction i) = (es, n, [EventInstruction i])
 tokenToEvent ps es n (TokenBeginElement name as isClosed _) =
     (es, n', if isClosed then [begin, end] else [begin])
@@ -318,7 +318,7 @@ checkXMLDecl bs0 Nothing =
         case parser $ decodeUtf8With lenientDecode nextChunk of
             AT.Fail{} -> fallback
             AT.Partial f -> await >>= maybe fallback (loop chunks f)
-            AT.Done _ (TokenBeginDocument attrs) -> findEncoding attrs
+            AT.Done _ (TokenXMLDeclaration attrs) -> findEncoding attrs
             AT.Done{} -> fallback
       where
         chunks = nextChunk : chunks0
@@ -454,7 +454,7 @@ parseToken de = (char '<' >> parseLt) <|> TokenContent <$> parseContent de False
                 char' '?'
                 char' '>'
                 newline <|> return ()
-                return $ TokenBeginDocument as
+                return $ TokenXMLDeclaration as
             else do
                 skipSpace
                 x <- T.pack <$> manyTill anyChar (try $ string "?>")

--- a/xml-conduit/Text/XML/Stream/Token.hs
+++ b/xml-conduit/Text/XML/Stream/Token.hs
@@ -27,7 +27,7 @@ import Control.Arrow (first)
 oneSpace :: Builder
 oneSpace = copyByteString " "
 
-data Token = TokenBeginDocument [TAttribute]
+data Token = TokenXMLDeclaration [TAttribute]
            | TokenInstruction Instruction
            | TokenBeginElement TName [TAttribute] Bool Int -- ^ indent
            | TokenEndElement TName
@@ -37,7 +37,7 @@ data Token = TokenBeginDocument [TAttribute]
            | TokenCDATA Text
     deriving Show
 tokenToBuilder :: Token -> Builder
-tokenToBuilder (TokenBeginDocument attrs) =
+tokenToBuilder (TokenXMLDeclaration attrs) =
     fromByteString "<?xml"
     `mappend` foldAttrs oneSpace attrs (fromByteString "?>")
 tokenToBuilder (TokenInstruction (Instruction target data_)) = mconcat

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -51,6 +51,7 @@ main = hspec $ do
         it "strips duplicated attributes" stripDuplicateAttributes
         it "displays comments" testRenderComments
         it "conduit parser" testConduitParser
+        it "can omit the XML declaration" omitXMLDeclaration
     describe "XML Cursors" $ do
         it "has correct parent" cursorParent
         it "has correct ancestor" cursorAncestor
@@ -527,6 +528,14 @@ testConduitParser = runResourceT $ do
         ma <- P.tagNoAttr "item" (return 1)
         maybe (return ()) (\a -> C.yield a >> f) ma
 
+omitXMLDeclaration :: Assertion
+omitXMLDeclaration = Res.renderLBS settings input @?= spec
+  where
+    settings = def { Res.rsXMLDeclaration = False }
+    input = Res.Document (Prologue [] Nothing [])
+              (Res.Element "foo" mempty [Res.NodeContent "bar"])
+              []
+    spec = "<foo>bar</foo>"
 
 name :: [Cu.Cursor] -> [Text]
 name [] = []

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -533,7 +533,7 @@ omitXMLDeclaration = Res.renderLBS settings input @?= spec
   where
     settings = def { Res.rsXMLDeclaration = False }
     input = Res.Document (Prologue [] Nothing [])
-              (Res.Element "foo" mempty [Res.NodeContent "bar"])
+              (Res.Element "foo" Map.empty [Res.NodeContent "bar"])
               []
     spec = "<foo>bar</foo>"
 

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -1,5 +1,5 @@
 name:            xml-conduit
-version:         1.5.0
+version:         1.5.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Aristid Breitkreuz <aristidb@googlemail.com>


### PR DESCRIPTION
In-band encoding information can be unreliable, so it can sometimes be
preferable to omit it entirely; content-sniffing for XML is similarly
unreliable. Without these considerations, there is no need for an XML
declaration. The default is to retain the XML declaration for bytewise
output stability.

In addition, the internal-only constructor TokenBeginDocument that
stores the XML declaration's attributes has been renamed
TokenXMLDeclaration to reduce confusion, as not every document begins
with an XML declaration; this was already the case for parsing, and is
now also the case for rendering.

Since this is a new feature, I've also bumped the version (and updated the changelog); I *think* that the third component is the right one to bump, since this isn't a breaking change, but it's also not written anywhere that xml-conduit follows the PVP.