### PR TITLE
Drop dependency on data-class for data-default-class.

### DIFF
--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.0
+
+* Dropped the dependency on `data-default` for `data-default-class`, reducing the transitive dependency load. For most users, this will not be a breaking change, but it does mean that importing `Text.XML.Conduit` will no longer bring various instances for `Default` into scope. This will break code that relies on those instances and does not otherwise see them. To fix this, import `Data.Default` from `data-default` or one of the more specific instance-providing packages directly (e.g., `data-default-dlist` for the `DList` instance).
+
 ## 1.5.1
 
 * New render setting, `rsXMLDeclaration`; setting it to `False` omits the XML declaration.

--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -181,7 +181,7 @@ import           Data.Conduit.Attoparsec      (PositionRange, conduitParser)
 import           Data.Conduit.Binary          (sourceFile)
 import qualified Data.Conduit.List            as CL
 import qualified Data.Conduit.Text            as CT
-import           Data.Default                 (Default (..))
+import           Data.Default.Class           (Default (..))
 import           Data.List                    (intercalate)
 import           Data.List                    (foldl')
 import qualified Data.Map                     as Map

--- a/xml-conduit/Text/XML/Stream/Render.hs
+++ b/xml-conduit/Text/XML/Stream/Render.hs
@@ -37,7 +37,7 @@ import           Data.Conduit
 import           Data.Conduit.Blaze           (builderToByteString)
 import qualified Data.Conduit.List            as CL
 import qualified Data.Conduit.Text            as CT
-import           Data.Default                 (Default (def))
+import           Data.Default.Class           (Default (def))
 import           Data.List                    (foldl')
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -1,5 +1,5 @@
 name:            xml-conduit
-version:         1.5.1
+version:         1.6.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Aristid Breitkreuz <aristidb@googlemail.com>
@@ -27,7 +27,7 @@ library
                    , attoparsec                >= 0.10
                    , blaze-builder             >= 0.2      && < 0.5
                    , transformers              >= 0.2      && < 0.6
-                   , data-default
+                   , data-default-class
                    , monad-control             >= 0.3      && < 1.1
                    , blaze-markup              >= 0.5
                    , blaze-html                >= 0.5


### PR DESCRIPTION
We don't use anything outside the class itself, and data-class sucks
in a bunch of transitive dependencies. This has the potential to break
user code, as we are no longer re-exporting data-default's
batteries-included instances, so the version has been bumped.