### PR TITLE
Fix hexadecimal character reference parsing.

### DIFF
--- a/html-conduit/html-conduit.cabal
+++ b/html-conduit/html-conduit.cabal
@@ -22,7 +22,7 @@ Library
                      , resourcet                        >= 0.3            && < 1.2
                      , conduit                          >= 1.0            && < 1.3
                      , conduit-extra                    >= 1.1.1
-                     , xml-conduit                      >= 1.3            && < 1.7
+                     , xml-conduit                      >= 1.3            && < 1.8
                      , tagstream-conduit                >= 0.5.5.3        && < 0.6
                      , xml-types                        >= 0.3            && < 0.4
 

--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,3 +1,9 @@
+## 1.7.0
+
+* `psDecodeEntities` is no longer passed numeric character references (e.g., `&#x20;`, `&#65;`) and the predefined XML entities (`&amp;`, `&lt;`, etc). They are now handled by the parser. Both of these construct classes only have one spec-compliant interpretation and this behaviour must always be present, so it makes no sense to force user code to re-implement the parsing logic.
+* In prior versions of xml-conduit, hexadecimal character references with a leading `0x` or `0X` like `&0x20;` were accepted. This was not in compliance with the XML specification and it has been corrected.
+* xml-conduit now rejects some (but not all) invalid-according-to-spec entities during parsing: specifically, entities with a leading `#` that are not character references are no longer allowed and will be parse errors.
+
 ## 1.6.0
 
 * Dropped the dependency on `data-default` for `data-default-class`, reducing the transitive dependency load. For most users, this will not be a breaking change, but it does mean that importing `Text.XML.Conduit` will no longer bring various instances for `Default` into scope. This will break code that relies on those instances and does not otherwise see them. To fix this, import `Data.Default` from `data-default` or one of the more specific instance-providing packages directly (e.g., `data-default-dlist` for the `DList` instance).

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -1,5 +1,5 @@
 name:            xml-conduit
-version:         1.6.0
+version:         1.7.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Aristid Breitkreuz <aristidb@googlemail.com>

--- a/xml-hamlet/xml-hamlet.cabal
+++ b/xml-hamlet/xml-hamlet.cabal
@@ -19,7 +19,7 @@ Library
   
   Build-depends:       base                       >= 4        && < 5
                      , shakespeare                >= 1.0      && < 2.2
-                     , xml-conduit                >= 1.0      && < 1.7
+                     , xml-conduit                >= 1.0      && < 1.8
                      , text                       >= 0.10
                      , template-haskell
                      , parsec                     >= 2.0      && < 3.2


### PR DESCRIPTION
This is three related fixes for spec infelicities:

* xml-conduit would happily decode entities of the form
  '&#x0xNNN;', where NNN is any hexadecimal string. But that's just
  flagrantly wrong; that ought to be an error.

* Second, xml-conduit would also accept 'entities' whose name started
  with a hash and which weren't legal character references. However,
  these cannot be legal entity names, so we now reject them at parse time.

* Third, there were no checks on whether a character reference was a
  legal XML character. These checks have now been added.

To implement this, we now directly decode character references and the
predefeined entities in the parser, entirely removing the possibility
of user code changing that behaviour via `psDecodeEntities` and hence
closing #105.

I've bumped the version because behaviour change and some inputs are going to be newly rejected. Might be arguable that this is a bug fix, but `decodeXmlEntities` has changed quite significantly.

Also, I *think* this is going to break the stack builds with older LTSes on Travis because of the new `fail` dep and the tighter `attoparsec` lower bound, but I'm not sure of it, so please let them run before thinking about merging. If they do break, some advice on fixing it would be welcome: should I add in those packages to `extra-deps` in `stack.yaml`, even though newer LTSes work fine without and we'll lag behind the versions available in those newer LTSes?