### PR TITLE
Update Text.XML.Stream.Parse example

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -27,9 +27,10 @@
 --
 -- > {-# LANGUAGE OverloadedStrings #-}
 -- > import Control.Monad.Trans.Resource
--- > import Data.Conduit (($$))
+-- > import Data.Conduit (Consumer, Sink, ($$))
 -- > import Data.Text (Text, unpack)
 -- > import Text.XML.Stream.Parse
+-- > import Data.XML.Types (Event)
 -- >
 -- > data Person = Person Int Text
 -- >     deriving Show


### PR DESCRIPTION
Closes #113 

According to [counduit docs](https://github.com/snoyberg/conduit#legacy-syntax) the `($$)` operator is considered legacy syntax. Should operators be updated as well?