### PR TITLE
Take advantage of stream fusion during text content decoding.

### DIFF
--- a/xml-conduit/Text/XML/Unresolved.hs
+++ b/xml-conduit/Text/XML/Unresolved.hs
@@ -58,6 +58,7 @@ import           Data.Conduit
 import qualified Data.Conduit.Binary          as CB
 import           Data.Conduit.Lazy            (lazyConsume)
 import qualified Data.Conduit.List            as CL
+import           Data.Maybe                   (isJust, mapMaybe)
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import qualified Data.Text.Lazy               as TL
@@ -268,10 +269,16 @@ elementToEvents' = goE
     goN' (NodeComment t)     = (EventComment t :)
 
 compressNodes :: [Node] -> [Node]
-compressNodes [] = []
-compressNodes [x] = [x]
-compressNodes (NodeContent (ContentText x) : NodeContent (ContentText y) : z) =
-    compressNodes $ NodeContent (ContentText $ x `T.append` y) : z
+compressNodes []     = []
+compressNodes [x]    = [x]
+compressNodes (x@(NodeContent (ContentText _)) : y@(NodeContent (ContentText _)) : z) =
+    let (textNodes, remainder) = span (isJust . unContent) (x:y:z)
+        texts = mapMaybe unContent textNodes
+    in
+        compressNodes $ NodeContent (ContentText $ foldl T.append T.empty texts) : remainder
+    where
+        unContent (NodeContent (ContentText text)) = Just text
+        unContent _                                = Nothing
 compressNodes (x:xs) = x : compressNodes xs
 
 parseText :: ParseSettings -> TL.Text -> Either SomeException Document

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -1,5 +1,5 @@
 name:            xml-conduit
-version:         1.7.0
+version:         1.7.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Aristid Breitkreuz <aristidb@googlemail.com>


### PR DESCRIPTION
`Text.XML.Unresolved.elementFromEvents` coalesces adjacent text nodes. The old algorithm coalesced pairwise and recursively in a way that defeats Text stream fusion. It's been replaced with a new one that coalesces an entire contiguous block of text nodes at once, and which can take advantage of stream fusion.