### PR TITLE
Allow users to specify how illegal characters should be decoded

### DIFF
--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.7.1
+
+* Add `psDecodeIllegalCharacters` field in `ParseSettings` to specify how illegal characters references should be decoded
+
 ## 1.7.0
 
 * `psDecodeEntities` is no longer passed numeric character references (e.g., `&#x20;`, `&#65;`) and the predefined XML entities (`&amp;`, `&lt;`, etc). They are now handled by the parser. Both of these construct classes only have one spec-compliant interpretation and this behaviour must always be present, so it makes no sense to force user code to re-implement the parsing logic.

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -545,9 +545,9 @@ hexEntityParsing = do
   it "rejects leading 0X" $
     go "<foo>&#x0Xff;</foo>" @?= Nothing
   it "accepts lowercase hex digits" $
-    go "<foo>&#xff;</foo>" @?= Just spec
+    go "<foo>&#xff;</foo>" @?= Just (spec "\xff")
   it "accepts uppercase hex digits" $
-    go "<foo>&#xFF;</foo>" @?= Just spec
+    go "<foo>&#xFF;</foo>" @?= Just (spec "\xff")
   --Note: this must be rejected, because, according to the XML spec, a
   --legal EntityRef's entity matches Name, which can't start with a
   --hash.
@@ -568,17 +568,19 @@ hexEntityParsing = do
   it "rejects illegal character #x1F" $
     go "<foo>&#x1F;</foo>" @?= Nothing
   it "accepts astral plane character" $
-    go "<foo>&#x1006ff;</foo>" @?= Just astralSpec
+    go "<foo>&#x1006ff;</foo>" @?= Just (spec "\x1006ff")
+  it "accepts custom character references" $
+    go' customSettings "<foo>&#xC;</foo>" @?= Just (spec "\xff")
   where
-    spec = Document (Prologue [] Nothing [])
-                    (Element "foo" [] [NodeContent (ContentText "\xff")])
-                    []
-
-    astralSpec = Document (Prologue [] Nothing [])
-                    (Element "foo" [] [NodeContent (ContentText "\x1006ff")])
+    spec content = Document (Prologue [] Nothing [])
+                    (Element "foo" [] [NodeContent (ContentText content)])
                     []
 
     go = either (const Nothing) Just . D.parseLBS def
+    go' settings = either (const Nothing) Just . D.parseLBS settings
+    customSettings = def { P.psDecodeIllegalCharacters = customDecoder }
+    customDecoder 12 = Just '\xff'
+    customDecoder _  = Nothing
 
 name :: [Cu.Cursor] -> [Text]
 name [] = []


### PR DESCRIPTION
Fixes #119.
This is a work-in-progress (missing unit tests) for review (@zudov).