### PR TITLE
Render.hs:Attributes:  define a Semigroup instance (GHC 8.4 compat)

### DIFF
--- a/xml-conduit/Text/XML/Stream/Render.hs
+++ b/xml-conduit/Text/XML/Stream/Render.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP  #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
@@ -404,7 +405,12 @@ data Attributes = Attributes [(Name, [Content])]
 
 instance Monoid Attributes where
   mempty = Attributes mempty
+#if !MIN_VERSION_base(4,11,0)
   (Attributes a) `mappend` (Attributes b) = Attributes (a `mappend` b)
+#else
+instance Semigroup Attributes where
+  (Attributes a) <> (Attributes b) = Attributes (a <> b)
+#endif
 
 -- | Generate a single attribute.
 attr :: Name        -- ^ Attribute's name


### PR DESCRIPTION
Fixes #121. Tested on GHC 8.4-alpha1 and 8.0.2.