### PR TITLE
Support for upcoming conduit 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,15 +44,15 @@ matrix:
   #- env: BUILD=cabal GHCVER=7.4.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #  compiler: ": #GHC 7.4.2"
   #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.6.3"
-    addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  #- env: BUILD=cabal GHCVER=7.6.3 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.6.3"
+  #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  #- env: BUILD=cabal GHCVER=7.8.4 CABALVER=1.18 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.8.4"
+  #  addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  #- env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.10.3"
+  #  addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.1"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
@@ -78,17 +78,17 @@ matrix:
     compiler: ": #stack default"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-2"
-    compiler: ": #stack 7.8.4"
-    addons: {apt: {packages: [libgmp-dev]}}
+  #- env: BUILD=stack ARGS="--resolver lts-2"
+  #  compiler: ": #stack 7.8.4"
+  #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2"
-    addons: {apt: {packages: [libgmp-dev]}}
+  #- env: BUILD=stack ARGS="--resolver lts-3"
+  #  compiler: ": #stack 7.10.2"
+  #  addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3"
-    addons: {apt: {packages: [libgmp-dev]}}
+  #- env: BUILD=stack ARGS="--resolver lts-6"
+  #  compiler: ": #stack 7.10.3"
+  #  addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-7"
     compiler: ": #stack 8.0.1"
@@ -121,13 +121,13 @@ matrix:
   #  compiler: ": #stack 7.8.4 osx"
   #  os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2 osx"
-    os: osx
+  #- env: BUILD=stack ARGS="--resolver lts-3"
+  #  compiler: ": #stack 7.10.2 osx"
+  #  os: osx
 
-  - env: BUILD=stack ARGS="--resolver lts-6"
-    compiler: ": #stack 7.10.3 osx"
-    os: osx
+  #- env: BUILD=stack ARGS="--resolver lts-6"
+  #  compiler: ": #stack 7.10.3 osx"
+  #  os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-7"
     compiler: ": #stack 8.0.1 osx"

--- a/html-conduit/ChangeLog.md
+++ b/html-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+* Upgrade to conduit 1.3
+
 ## 1.2.1.2
 
 * Remove an upper bound

--- a/html-conduit/Text/HTML/DOM.hs
+++ b/html-conduit/Text/HTML/DOM.hs
@@ -17,8 +17,6 @@ import qualified Data.ByteString as S
 import qualified Text.HTML.TagStream.Text as TS
 import qualified Text.HTML.TagStream as TS
 import qualified Data.XML.Types as XT
-import Data.Conduit
-import Data.Conduit.Text (decodeUtf8Lenient)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Conduit.List as CL
@@ -26,7 +24,7 @@ import Control.Arrow ((***))
 import qualified Data.Set as Set
 import qualified Text.XML as X
 import Text.XML.Stream.Parse (decodeHtmlEntities)
-import Data.Conduit.Binary (sourceFile)
+import Conduit
 import qualified Data.ByteString.Lazy as L
 import Data.Maybe (mapMaybe)
 
@@ -34,15 +32,15 @@ import Data.Maybe (mapMaybe)
 --
 -- Note that there may be multiple (or not) root elements. @sinkDoc@ addresses
 -- that case.
-eventConduit :: Monad m => Conduit S.ByteString m XT.Event
-eventConduit = decodeUtf8Lenient =$= eventConduit' 
+eventConduit :: Monad m => ConduitT S.ByteString XT.Event m ()
+eventConduit = decodeUtf8LenientC .| eventConduit'
 
-eventConduitText :: Monad m => Conduit T.Text m XT.Event
+eventConduitText :: Monad m => ConduitT T.Text XT.Event m ()
 eventConduitText = eventConduit'
 
-eventConduit' :: Monad m => Conduit T.Text m XT.Event
-eventConduit' = 
-    TS.tokenStream =$= go []
+eventConduit' :: Monad m => ConduitT T.Text XT.Event m ()
+eventConduit' =
+    TS.tokenStream .| go []
   where
     go stack = do
         mx <- await
@@ -99,15 +97,18 @@ eventConduit' =
         , "wbr"
         ]
 
-sinkDoc :: MonadThrow m => Sink S.ByteString m X.Document
-sinkDoc = sinkDoc' eventConduit 
+sinkDoc :: MonadThrow m => ConduitT S.ByteString o m X.Document
+sinkDoc = sinkDoc' eventConduit
 
-sinkDocText :: MonadThrow m => Sink T.Text m X.Document
+sinkDocText :: MonadThrow m => ConduitT T.Text o m X.Document
 sinkDocText = sinkDoc' eventConduitText
 
-sinkDoc' :: (Monad m, MonadThrow m) => Conduit a m XT.Event -> Sink a m X.Document
-sinkDoc' f = 
-    fmap stripDummy $ mapOutput ((,) Nothing) f =$ addDummyWrapper =$ X.fromEvents
+sinkDoc'
+  :: MonadThrow m
+  => ConduitT a XT.Event m ()
+  -> ConduitT a o m X.Document
+sinkDoc' f =
+    fmap stripDummy $ mapOutput ((,) Nothing) f .| addDummyWrapper .| X.fromEvents
   where
     addDummyWrapper = do
         yield (Nothing, XT.EventBeginElement "html" [])
@@ -123,7 +124,7 @@ sinkDoc' f =
     toElement _ = Nothing
 
 readFile :: FilePath -> IO X.Document
-readFile fp = runResourceT $ sourceFile fp $$ sinkDoc
+readFile fp = withSourceFile fp $ \src -> runConduit $ src .| sinkDoc
 
 parseLBS :: L.ByteString -> X.Document
 parseLBS = parseBSChunks . L.toChunks

--- a/html-conduit/Text/HTML/DOM.hs
+++ b/html-conduit/Text/HTML/DOM.hs
@@ -23,7 +23,6 @@ import qualified Data.Conduit.List as CL
 import Control.Arrow ((***))
 import qualified Data.Set as Set
 import qualified Text.XML as X
-import Text.XML.Stream.Parse (decodeHtmlEntities)
 import Conduit
 import qualified Data.ByteString.Lazy as L
 import Data.Maybe (mapMaybe)

--- a/html-conduit/html-conduit.cabal
+++ b/html-conduit/html-conduit.cabal
@@ -21,7 +21,6 @@ Library
                      , text
                      , resourcet                        >= 1.2
                      , conduit                          >= 1.3
-                     , conduit-extra                    >= 1.3
                      , xml-conduit                      >= 1.3
                      , tagstream-conduit                >= 0.5.5.3        && < 0.6
                      , xml-types                        >= 0.3            && < 0.4

--- a/html-conduit/html-conduit.cabal
+++ b/html-conduit/html-conduit.cabal
@@ -19,9 +19,9 @@ Library
                      , bytestring
                      , containers
                      , text
-                     , resourcet                        >= 0.3            && < 1.2
-                     , conduit                          >= 1.0            && < 1.3
-                     , conduit-extra                    >= 1.1.1
+                     , resourcet                        >= 1.2
+                     , conduit                          >= 1.3
+                     , conduit-extra                    >= 1.3
                      , xml-conduit                      >= 1.3
                      , tagstream-conduit                >= 0.5.5.3        && < 0.6
                      , xml-types                        >= 0.3            && < 0.4

--- a/html-conduit/html-conduit.cabal
+++ b/html-conduit/html-conduit.cabal
@@ -1,5 +1,5 @@
 Name:                html-conduit
-Version:             1.2.1.2
+Version:             1.3.0
 Synopsis:            Parse HTML documents using xml-conduit datatypes.
 Description:         This package uses tagstream-conduit for its parser. It automatically balances mismatched tags, so that there shouldn't be any parse failures. It does not handle a full HTML document rendering, such as adding missing html and head tags.
 Homepage:            https://github.com/snoyberg/xml

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,3 +9,4 @@ extra-deps:
 - resourcet-1.2.0
 - mono-traversable-1.0.8.1
 - unliftio-core-0.1.1.0
+- typed-process-0.2.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,10 @@ packages:
 - xml-conduit/
 - xml-hamlet/
 - html-conduit/
-resolver: lts-6.17
+resolver: lts-10.3
+extra-deps:
+- conduit-1.3.0
+- conduit-extra-1.3.0
+- resourcet-1.2.0
+- mono-traversable-1.0.8.1
+- unliftio-core-0.1.1.0

--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,6 +1,6 @@
-## 1.7.0.1
+## 1.8.0
 
-* Use `throwM` instead of `monadThrow`
+* Upgrade to conduit 1.3.0
 
 ## 1.7.0
 

--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.7.0.1
+
+* Use `throwM` instead of `monadThrow`
+
 ## 1.7.0
 
 * `psDecodeEntities` is no longer passed numeric character references (e.g., `&#x20;`, `&#65;`) and the predefined XML entities (`&amp;`, `&lt;`, etc). They are now handled by the parser. Both of these construct classes only have one spec-compliant interpretation and this behaviour must always be present, so it makes no sense to force user code to re-implement the parsing logic.

--- a/xml-conduit/Text/XML.hs
+++ b/xml-conduit/Text/XML.hs
@@ -74,12 +74,12 @@ module Text.XML
     , fromXMLElement
     ) where
 
+import           Conduit
 import           Control.Applicative          ((<$>))
 import           Control.DeepSeq              (NFData (rnf))
 import           Control.Exception            (Exception, SomeException, handle,
                                                throw, throwIO)
-import           Control.Monad.ST             (runST)
-import           Control.Monad.Trans.Resource (MonadThrow, throwM, runResourceT)
+import           Control.Monad.Trans.Resource (MonadThrow, throwM)
 import           Data.ByteString              (ByteString)
 import qualified Data.ByteString.Lazy         as L
 import           Data.Data                    (Data)
@@ -103,7 +103,6 @@ import qualified Text.XML.Stream.Render       as R
 import qualified Text.XML.Unresolved          as D
 
 import           Control.Monad.Trans.Class    (lift)
-import           Data.Conduit
 import qualified Data.Conduit.Binary          as CB
 import           Data.Conduit.Lazy            (lazyConsume)
 import qualified Data.Conduit.List            as CL
@@ -227,7 +226,7 @@ fromXMLNode (X.NodeInstruction i) = Right $ NodeInstruction i
 readFile :: ParseSettings -> FilePath -> IO Document
 readFile ps fp = handle
     (throwIO . InvalidXMLFile fp)
-    (runResourceT $ CB.sourceFile fp $$ sinkDoc ps)
+    (runConduitRes $ CB.sourceFile fp .| sinkDoc ps)
 
 data XMLException = InvalidXMLFile FilePath SomeException
     deriving Typeable
@@ -252,8 +251,8 @@ parseLBS_ ps = either throw id . parseLBS ps
 
 sinkDoc :: MonadThrow m
         => ParseSettings
-        -> Consumer ByteString m Document
-sinkDoc ps = P.parseBytesPos ps =$= fromEvents
+        -> ConduitT ByteString o m Document
+sinkDoc ps = P.parseBytesPos ps .| fromEvents
 
 parseText :: ParseSettings -> TL.Text -> Either SomeException Document
 parseText ps tl
@@ -266,10 +265,10 @@ parseText_ ps = either throw id . parseText ps
 
 sinkTextDoc :: MonadThrow m
             => ParseSettings
-            -> Consumer Text m Document
-sinkTextDoc ps = P.parseTextPos ps =$= fromEvents
+            -> ConduitT Text o m Document
+sinkTextDoc ps = P.parseTextPos ps .| fromEvents
 
-fromEvents :: MonadThrow m => Consumer P.EventPos m Document
+fromEvents :: MonadThrow m => ConduitT P.EventPos o m Document
 fromEvents = do
     d <- D.fromEvents
     either (lift . throwM . UnresolvedEntityException) return $ fromXMLDocument d
@@ -278,12 +277,12 @@ data UnresolvedEntityException = UnresolvedEntityException (Set Text)
     deriving (Show, Typeable)
 instance Exception UnresolvedEntityException
 
---renderBytes :: MonadUnsafeIO m => R.RenderSettings -> Document -> Producer m ByteString
+renderBytes :: PrimMonad m => D.RenderSettings -> Document -> ConduitT i ByteString m ()
 renderBytes rs doc = D.renderBytes rs $ toXMLDocument' rs doc
 
 writeFile :: R.RenderSettings -> FilePath -> Document -> IO ()
 writeFile rs fp doc =
-    runResourceT $ renderBytes rs doc $$ CB.sinkFile fp
+    runConduitRes $ renderBytes rs doc .| CB.sinkFile fp
 
 renderLBS :: R.RenderSettings -> Document -> L.ByteString
 renderLBS rs doc =

--- a/xml-conduit/Text/XML/Cursor.hs
+++ b/xml-conduit/Text/XML/Cursor.hs
@@ -60,7 +60,7 @@ module Text.XML.Cursor
 
 import           Control.Exception            (Exception)
 import           Control.Monad
-import           Control.Monad.Trans.Resource (MonadThrow, monadThrow)
+import           Control.Monad.Trans.Resource (MonadThrow, throwM)
 import           Data.Function                (on)
 import qualified Data.Map                     as Map
 import           Data.Maybe                   (maybeToList)
@@ -214,9 +214,9 @@ attributeIs n v c =
         _                            -> []
 
 force :: (Exception e, MonadThrow f) => e -> [a] -> f a
-force e []    = monadThrow e
+force e []    = throwM e
 force _ (x:_) = return x
 
 forceM :: (Exception e, MonadThrow f) => e -> [f a] -> f a
-forceM e []    = monadThrow e
+forceM e []    = throwM e
 forceM _ (x:_) = x

--- a/xml-conduit/Text/XML/Unresolved.hs
+++ b/xml-conduit/Text/XML/Unresolved.hs
@@ -43,7 +43,6 @@ module Text.XML.Unresolved
     , R.rsNamespaces
     ) where
 
-import           Blaze.ByteString.Builder     (Builder)
 import           Control.Applicative          ((<$>), (<*>))
 import           Control.Exception            (Exception, SomeException, throw)
 import           Control.Monad                (when)
@@ -51,6 +50,7 @@ import           Control.Monad.ST             (runST)
 import           Control.Monad.Trans.Class    (lift)
 import           Control.Monad.Trans.Resource (MonadThrow, throwM, runResourceT)
 import           Data.ByteString              (ByteString)
+import           Data.ByteString.Builder      (Builder)
 import qualified Data.ByteString.Lazy         as L
 import           Data.Char                    (isSpace)
 import           Data.Conduit

--- a/xml-conduit/test/main.hs
+++ b/xml-conduit/test/main.hs
@@ -15,18 +15,15 @@ import           Text.XML.Stream.Parse        (def)
 import qualified Text.XML.Stream.Parse        as P
 import qualified Text.XML.Unresolved          as D
 
-import           Control.Applicative          ((<$>))
 import           Control.Monad
-import           Control.Monad.Trans.Class    (lift)
 import qualified Data.Set                     as Set
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import           Text.XML.Cursor              (($.//), ($/), ($//), ($|),
                                                (&.//), (&/), (&//))
 
-import           Control.Monad.Trans.Resource (runResourceT)
 import qualified Control.Monad.Trans.Resource as C
-import           Data.Conduit                 ((=$=))
+import           Data.Conduit                 ((.|), runConduit, runConduitRes, ConduitT)
 import qualified Data.Conduit                 as C
 import qualified Data.Conduit.List            as CL
 import qualified Data.Map                     as Map
@@ -139,7 +136,7 @@ documentParsePrettyRender =
         ]
 
 combinators :: Assertion
-combinators = runResourceT $ P.parseLBS def input C.$$ do
+combinators = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tag' "hello" (P.requireAttr "world") $ \world -> do
         liftIO $ world @?= "true"
         P.force "need child1" $ P.tagNoAttr "{mynamespace}child1" $ return ()
@@ -186,7 +183,7 @@ testChoose = do
         testChooseElemOrTextIsChunkedText2
 
 testChooseElemOrTextIsText :: Assertion
-testChooseElemOrTextIsText = runResourceT $ P.parseLBS def input C.$$ do
+testChooseElemOrTextIsText = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "failure" $ return "boom"
@@ -203,7 +200,7 @@ testChooseElemOrTextIsText = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseElemOrTextIsEncoded :: Assertion
-testChooseElemOrTextIsEncoded = runResourceT $ P.parseLBS def input C.$$ do
+testChooseElemOrTextIsEncoded = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "failure" $ return "boom"
@@ -220,7 +217,7 @@ testChooseElemOrTextIsEncoded = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseElemOrTextIsEncodedNBSP :: Assertion
-testChooseElemOrTextIsEncodedNBSP = runResourceT $ P.parseLBS def input C.$$ do
+testChooseElemOrTextIsEncodedNBSP = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "failure" $ return "boom"
@@ -238,7 +235,7 @@ testChooseElemOrTextIsEncodedNBSP = runResourceT $ P.parseLBS def input C.$$ do
 
 
 testChooseElemOrTextIsWhiteSpace :: Assertion
-testChooseElemOrTextIsWhiteSpace = runResourceT $ P.parseLBS def input C.$$ do
+testChooseElemOrTextIsWhiteSpace = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "failure" $ return "boom"
@@ -253,7 +250,7 @@ testChooseElemOrTextIsWhiteSpace = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseTextOrElemIsWhiteSpace :: Assertion
-testChooseTextOrElemIsWhiteSpace = runResourceT $ P.parseLBS def input C.$$ do
+testChooseTextOrElemIsWhiteSpace = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.contentMaybe
@@ -268,7 +265,7 @@ testChooseTextOrElemIsWhiteSpace = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseElemOrTextIsChunkedText :: Assertion
-testChooseElemOrTextIsChunkedText = runResourceT $ P.parseLBS def input C.$$ do
+testChooseElemOrTextIsChunkedText = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "failure" $ return "boom"
@@ -283,7 +280,7 @@ testChooseElemOrTextIsChunkedText = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseElemOrTextIsChunkedText2 :: Assertion
-testChooseElemOrTextIsChunkedText2 = runResourceT $ P.parseLBS def input C.$$ do
+testChooseElemOrTextIsChunkedText2 = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "failure" $ return "boom"
@@ -298,7 +295,7 @@ testChooseElemOrTextIsChunkedText2 = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseElemOrTextIsElem :: Assertion
-testChooseElemOrTextIsElem = runResourceT $ P.parseLBS def input C.$$ do
+testChooseElemOrTextIsElem = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "success" $ return "success"
@@ -315,7 +312,7 @@ testChooseElemOrTextIsElem = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseTextOrElemIsText :: Assertion
-testChooseTextOrElemIsText = runResourceT $ P.parseLBS def input C.$$ do
+testChooseTextOrElemIsText = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.contentMaybe
@@ -332,7 +329,7 @@ testChooseTextOrElemIsText = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseTextOrElemIsElem :: Assertion
-testChooseTextOrElemIsElem = runResourceT $ P.parseLBS def input C.$$ do
+testChooseTextOrElemIsElem = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.contentMaybe
@@ -349,7 +346,7 @@ testChooseTextOrElemIsElem = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testChooseEitherElem :: Assertion
-testChooseEitherElem = runResourceT $ P.parseLBS def input C.$$ do
+testChooseEitherElem = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.choose
             [ P.tagNoAttr "failure" $ return 1
@@ -368,9 +365,9 @@ testChooseEitherElem = runResourceT $ P.parseLBS def input C.$$ do
 testManyYield :: Assertion
 testManyYield = do
     -- Basically the same as testMany, but consume the streamed result
-    result <- runResourceT $
-        P.parseLBS def input C.$$ helloParser
-        =$= CL.consume
+    result <- runConduitRes $
+        P.parseLBS def input .| helloParser
+        .| CL.consume
     length result @?= 5
   where
     helloParser = void $ P.tagNoAttr "hello" $ P.manyYield successParser
@@ -389,12 +386,12 @@ testManyYield = do
 
 testTakeContent :: Assertion
 testTakeContent = do
-    result <- runResourceT $ P.parseLBS def input C.$$ rootParser
+    result <- runConduitRes $ P.parseLBS def input .| rootParser
     result @?= Just
       [ EventContent (ContentText "Hello world !")
       ]
   where
-    rootParser = P.tagNoAttr "root" $ void (P.takeContent >> P.takeContent) =$= CL.consume
+    rootParser = P.tagNoAttr "root" $ void (P.takeContent >> P.takeContent) .| CL.consume
     input = L.concat
         [ "<?xml version='1.0'?>"
         , "<!DOCTYPE foo []>\n"
@@ -405,7 +402,7 @@ testTakeContent = do
 
 testTakeTree :: Assertion
 testTakeTree = do
-    result <- runResourceT $ P.parseLBS def input C.$$ rootParser
+    result <- runConduitRes $ P.parseLBS def input .| rootParser
     result @?=
       [ EventBeginDocument
       , EventBeginDoctype "foo" Nothing
@@ -417,7 +414,7 @@ testTakeTree = do
       , EventEndElement "a"
       ]
   where
-    rootParser = void (P.takeTree "a" P.ignoreAttrs) =$= CL.consume
+    rootParser = void (P.takeTree "a" P.ignoreAttrs) .| CL.consume
     input = L.concat
         [ "<?xml version='1.0'?>"
         , "<!DOCTYPE foo []>\n"
@@ -430,7 +427,7 @@ testTakeTree = do
 
 testTakeAnyTreeContent :: Assertion
 testTakeAnyTreeContent = do
-    result <- runResourceT $ P.parseLBS def input C.$$ rootParser
+    result <- runConduitRes $ P.parseLBS def input .| rootParser
     result @?= Just
       [ EventBeginElement "b" []
       , EventContent (ContentText "Hello ")
@@ -441,7 +438,7 @@ testTakeAnyTreeContent = do
       , EventEndElement "b"
       ]
   where
-    rootParser = P.tagNoAttr "root" $ (P.takeAnyTreeContent >> void P.ignoreAnyTreeContent) =$= CL.consume
+    rootParser = P.tagNoAttr "root" $ (P.takeAnyTreeContent >> void P.ignoreAnyTreeContent) .| CL.consume
     input = L.concat
         [ "<?xml version='1.0'?>"
         , "<!DOCTYPE foo []>\n"
@@ -452,7 +449,7 @@ testTakeAnyTreeContent = do
 
 
 testMany :: Assertion
-testMany = runResourceT $ P.parseLBS def input C.$$ do
+testMany = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.many $ P.tagNoAttr "success" $ return ()
         liftIO $ length x @?= 5
@@ -470,7 +467,7 @@ testMany = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testMany' :: Assertion
-testMany' = runResourceT $ P.parseLBS def input C.$$ do
+testMany' = runConduitRes $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.many' $ P.tagNoAttr "success" $ return ()
         liftIO $ length x @?= 5
@@ -490,7 +487,7 @@ testMany' = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testOrE :: IO ()
-testOrE = runResourceT $ P.parseLBS def input C.$$ do
+testOrE = runConduitRes $ runConduit $ P.parseLBS def input .| do
     P.force "need hello" $ P.tagNoAttr "hello" $ do
         x <- P.tagNoAttr "failure" (return 1) `P.orE`
              P.tagNoAttr "success" (return 2)
@@ -509,10 +506,11 @@ testOrE = runResourceT $ P.parseLBS def input C.$$ do
         ]
 
 testConduitParser :: Assertion
-testConduitParser = runResourceT $ do
-    x <- P.parseLBS def input
-        C.$$ (P.force "need hello" $ P.tagNoAttr "hello" f)
-        =$= CL.consume
+testConduitParser = do
+    x <-   runConduitRes
+         $ P.parseLBS def input
+        .| (P.force "need hello" $ P.tagNoAttr "hello" f)
+        .| CL.consume
     liftIO $ x @?= [1, 1, 1]
   where
     input = L.concat
@@ -524,7 +522,7 @@ testConduitParser = runResourceT $ do
         , "<item/>"
         , "</hello>"
         ]
-    f :: C.MonadThrow m => C.Conduit Event m Int
+    f :: C.MonadThrow m => ConduitT Event Int m ()
     f = do
         ma <- P.tagNoAttr "item" (return 1)
         maybe (return ()) (\a -> C.yield a >> f) ma
@@ -856,8 +854,8 @@ caseAttrReorder = do
             , "<bar a=\"a\" b=\"b\" c=\"c\"/>"
             , "</foo>"
             ]
-        rs = def { Res.rsAttrOrder = \name m ->
-                        case name of
+        rs = def { Res.rsAttrOrder = \name' m ->
+                        case name' of
                             "foo" -> reverse $ Map.toAscList m
                             _     -> Map.toAscList m
                  }

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -17,9 +17,9 @@ extra-source-files: test/main.hs
 
 library
     build-depends:   base                      >= 4        && < 5
-                   , conduit                   >= 1.0      && < 1.3
+                   , conduit                   >= 1.3      && < 1.4
                    , conduit-extra             >= 1.1
-                   , resourcet                 >= 0.3      && < 1.2
+                   , resourcet                 >= 1.2      && < 1.3
                    , bytestring                >= 0.9
                    , text                      >= 0.7
                    , containers                >= 0.2

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -18,14 +18,13 @@ extra-source-files: test/main.hs
 library
     build-depends:   base                      >= 4        && < 5
                    , conduit                   >= 1.3      && < 1.4
-                   , conduit-extra             >= 1.1
+                   , conduit-extra             >= 1.3      && < 1.4
                    , resourcet                 >= 1.2      && < 1.3
-                   , bytestring                >= 0.9
+                   , bytestring                >= 0.10.2
                    , text                      >= 0.7
                    , containers                >= 0.2
                    , xml-types                 >= 0.3.4    && < 0.4
                    , attoparsec                >= 0.10
-                   , blaze-builder             >= 0.2      && < 0.5
                    , transformers              >= 0.2      && < 0.6
                    , data-default-class
                    , monad-control             >= 0.3      && < 1.1

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -1,5 +1,5 @@
 name:            xml-conduit
-version:         1.7.0
+version:         1.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Aristid Breitkreuz <aristidb@googlemail.com>

--- a/xml-hamlet/ChangeLog.md
+++ b/xml-hamlet/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.5.0
+
+* Upgrade to conduit 1.3
+
 ## 0.4.1.1
 
 * Remove an upper bound

--- a/xml-hamlet/test/main.hs
+++ b/xml-hamlet/test/main.hs
@@ -124,7 +124,7 @@ $else
           justTrue = Just True
       in [xml|
 $case nothing
-    $of Just val
+    $of Just _val
     $of Nothing
         <one>
 $case justTrue
@@ -138,7 +138,7 @@ $case (Just $ not False)
         $if val
             <three>
 $case Nothing
-    $of Just val
+    $of Just _val
     $of _
         <four>
 |] @?=

--- a/xml-hamlet/xml-hamlet.cabal
+++ b/xml-hamlet/xml-hamlet.cabal
@@ -1,5 +1,5 @@
 Name:                xml-hamlet
-Version:             0.4.1.1
+Version:             0.5.0
 Synopsis:            Hamlet-style quasiquoter for XML content
 Homepage:            http://www.yesodweb.com/
 License:             BSD3


### PR DESCRIPTION
These are mostly mechanical transformations to work around the newly deprecated identifiers. It also introduces some speedups in the rendering code around builders, which was necessitated by conduit backing away from blaze-builder and sticking to Data.ByteString.Builder.

The new version of conduit isn't yet available, but it would be good to be able to release the new version of xml-conduit together with conduit 1.3.