### PR TITLE
takeContent now also covers entities

### DIFF
--- a/xml-conduit/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/Text/XML/Stream/Parse.hs
@@ -1072,8 +1072,8 @@ takeContent :: MonadThrow m => ConduitT Event Event m (Maybe ())
 takeContent = do
   event <- await
   case event of
-    Just e@(EventContent ContentText{}) -> yield e >> return (Just ())
-    Just e@EventCDATA{}                 -> yield e >> return (Just ())
+    Just e@EventContent{} -> yield e >> return (Just ())
+    Just e@EventCDATA{}   -> yield e >> return (Just ())
     Just e -> if isWhitespace e then yield e >> takeContent else leftover e >> return Nothing
     _ -> return Nothing
 


### PR DESCRIPTION
The `ContentEntity` event is consumed by none of the `take`* functions currently
defined in `Text.XML.Stream.Parse`. Rather than extending the API just for this
use case, I believe it is better to change the semantic of the existing `takeContent`
function, because:
- an entity is a substitute for actual content;
- users probably already assume that `takeContent` (and its derivatives like
  `takeAnyTreeContent`) consumes any `Content` event, since documentation fails
  to mention that entities were actually not covered.