### PR TITLE
Clean-up Text.XML.Stream.Parse API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,9 @@ matrix:
   - env: BUILD=cabal GHCVER=8.4.3 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.4.3"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.4.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.6.4 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.6.4"
+    addons: {apt: {packages: [cabal-install-1.24,ghc-8.6.4,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.

--- a/html-conduit/ChangeLog.md
+++ b/html-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.3.2.1
+
+* Upgrade to xml-conduit 1.9
+
 ## 1.3.2
 
 * Fix a bug that was removing `<` symbols in script tags.

--- a/html-conduit/html-conduit.cabal
+++ b/html-conduit/html-conduit.cabal
@@ -1,5 +1,5 @@
 Name:                html-conduit
-Version:             1.3.2
+Version:             1.3.2.1
 Synopsis:            Parse HTML documents using xml-conduit datatypes.
 Description:         This package uses tagstream-conduit for its parser. It automatically balances mismatched tags, so that there shouldn't be any parse failures. It does not handle a full HTML document rendering, such as adding missing html and head tags. Note that, since version 1.3.1, it uses an inlined copy of tagstream-conduit with entity decoding bugfixes applied.
 Homepage:            https://github.com/snoyberg/xml
@@ -23,7 +23,7 @@ Library
                      , text
                      , resourcet                        >= 1.2
                      , conduit                          >= 1.3
-                     , xml-conduit                      >= 1.3
+                     , xml-conduit                      >= 1.9
                      , xml-types                        >= 0.3            && < 0.4
 
                      -- tagstream-conduit deps

--- a/html-conduit/src/Text/HTML/TagStream.hs
+++ b/html-conduit/src/Text/HTML/TagStream.hs
@@ -149,7 +149,7 @@ decodeEntity :: MonadThrow m => Text -> m Text
 decodeEntity entity =
              runConduit
            $ CL.sourceList ["&",entity,";"]
-          .| XML.parseText' XML.def { XML.psDecodeEntities = XML.decodeHtmlEntities }
+          .| XML.parseText XML.def { XML.psDecodeEntities = XML.decodeHtmlEntities }
           .| XML.content
 
 token :: Parser Token

--- a/xml-conduit/ChangeLog.md
+++ b/xml-conduit/ChangeLog.md
@@ -1,3 +1,10 @@
+## 1.9.0
+
+* Remove deprecated functions (`ignoreTag`, `ignoreAllTreesContent`, `takeAllTreesContent`)
+* Rename `parseText'` into `parseText`
+* `takeContent` and `ignoreContent` now cover entities
+* Align behaviour of `take`* and `ignore`* functions
+
 ## 1.8.0.1
 
 * Use doctest to validate code examples from documentation

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -1,5 +1,5 @@
 name:            xml-conduit
-version:         1.8.0.1
+version:         1.9.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>, Aristid Breitkreuz <aristidb@googlemail.com>
@@ -13,6 +13,7 @@ build-type:      Simple
 homepage:        http://github.com/snoyberg/xml
 extra-source-files: README.md
                     ChangeLog.md
+tested-with:     GHC >=8.0 && <8.8
 
 library
     build-depends:   base                      >= 4        && < 5


### PR DESCRIPTION
This is a backward-incompatible change that includes:
- aligning the behavior of `take`* and `ignore`* functions
- adding doctests to those functions
- removing functions that have been deprecated for a while