### PR TITLE
Markup in entity

### DIFF
--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -52,7 +52,7 @@ main = hspec $ do
         it "displays comments" testRenderComments
         it "conduit parser" testConduitParser
         it "can omit the XML declaration" omitXMLDeclaration
-        it "can doesn't hang on malformed entity declarations" malformedEntityDeclaration
+        it "doesn't hang on malformed entity declarations" malformedEntityDeclaration
         context "correctly parses hexadecimal entities" hexEntityParsing
     describe "XML Cursors" $ do
         it "has correct parent" cursorParent

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -59,6 +59,7 @@ test-suite unit
                           , HUnit
                           , xml-types >= 0.3.1
                           , conduit
+                          , conduit-extra
                           , blaze-markup
                           , resourcet
     default-language: Haskell2010


### PR DESCRIPTION
This PR was primarily motivated by the need to fix #162.  I've encountered real-world XML files that this library cannot handle because of this limitation (including some sample DocBook files).

In testing, I discovered a case where the parser did not return at all (instead going into an infinite loop).  This came from the last line of `parseEntities` (now renamed `parseDeclarations`):
``` hs
         (skipWhile (\t -> t /= ']' && t /= '<') >> parseEntities front)
```
which could succeed without consuming any input.  (This code has been there for a while and was untouched by my recent changes.)

To avoid this, in a subsequent commit I rewrite the token parsers a bit, to avoid cases where malformed XML could cause a loop.  I also added `<?>` combinators to make the error information a bit more informative.
