### PR TITLE
Improvements for editing files written and read by humans

### DIFF
--- a/xml-conduit/src/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/src/Text/XML/Stream/Parse.hs
@@ -200,7 +200,7 @@ tokenToEvent ps es n (TokenBeginElement name as isClosed _) =
 
         addNS
             | not (psRetainNamespaces ps) && (isPrefixed || isUnprefixed) = id
-            | otherwise = (((tname, resolveEntities' ps es val):) .)
+            | otherwise = (. ((tname, resolveEntities' ps es val):))
           where
             resolveEntities' ps' es' xs =
               mapMaybe extractTokenContent

--- a/xml-conduit/src/Text/XML/Stream/Token.hs
+++ b/xml-conduit/src/Text/XML/Stream/Token.hs
@@ -96,11 +96,11 @@ contentToText (ContentEntity e) = "&" <> encodeUtf8Builder e <> ";"
 charUtf8XmlEscaped :: E.BoundedPrim Word8
 charUtf8XmlEscaped =
     condB (>  _gt) (E.liftFixedToBounded E.word8) $
-    condB (== _lt) (fixed4 (_am,(_l,(_t,_sc)))) $       -- &lt;
-    condB (== _gt) (fixed4 (_am,(_g,(_t,_sc)))) $       -- &gt;
-    condB (== _am) (fixed5 (_am,(_a,(_m,(_p,_sc))))) $  -- &amp;
-    condB (== _dq) (fixed5 (_am,(_ha,(_3,(_4,_sc))))) $ -- &#34;
-    condB (== _sq) (fixed5 (_am,(_ha,(_3,(_9,_sc))))) $ -- &#39;
+    condB (== _lt) (fixed4 (_am,(_l,(_t,_sc)))) $           -- &lt;
+    condB (== _gt) (fixed4 (_am,(_g,(_t,_sc)))) $           -- &gt;
+    condB (== _am) (fixed5 (_am,(_a,(_m,(_p,_sc))))) $      -- &amp;
+    condB (== _dq) (fixed6 (_am,(_q,(_u,(_o,(_t,_sc)))))) $ -- &quot;
+    condB (== _sq) (fixed6 (_am,(_a,(_p,(_o,(_s,_sc)))))) $ -- &apos;
     (E.liftFixedToBounded E.word8)         -- fallback for Chars smaller than '>'
   where
     _gt = 62 -- >
@@ -114,10 +114,10 @@ charUtf8XmlEscaped =
     _a  = 97  -- a
     _m  = 109 -- m
     _p  = 112 -- p
-    _3  = 51  -- 3
-    _4  = 52  -- 4
-    _ha = 35  -- #, hash
-    _9  = 57  -- 9
+    _o  = 111 -- o
+    _s  = 115 -- s
+    _q  = 113 -- q
+    _u  = 117 -- u
     _sc = 59  -- ;
     {-# INLINE fixed4 #-}
     fixed4 x = E.liftFixedToBounded $ const x >$<
@@ -126,6 +126,10 @@ charUtf8XmlEscaped =
     {-# INLINE fixed5 #-}
     fixed5 x = E.liftFixedToBounded $ const x >$<
       E.word8 >*< E.word8 >*< E.word8 >*< E.word8 >*< E.word8
+
+    {-# INLINE fixed6 #-}
+    fixed6 x = E.liftFixedToBounded $ const x >$<
+      E.word8 >*< E.word8 >*< E.word8 >*< E.word8 >*< E.word8 >*< E.word8
 
 type TAttribute = (TName, [Content])
 

--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -111,6 +111,7 @@ main = hspec $ do
     it "handles iso-8859-1" caseIso8859_1
     it "renders CDATA when asked" caseRenderCDATA
     it "escapes CDATA closing tag in CDATA" caseEscapesCDATA
+    it "escapes \" in attributes" caseEscapesQuot
 
 documentParseRender :: IO ()
 documentParseRender =
@@ -1041,3 +1042,12 @@ caseEscapesCDATA = do
                 []
         result = Res.renderLBS (def { Res.rsUseCDATA = const True }) doc
     result `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a><![CDATA[]]]]><![CDATA[>]]></a>"
+
+caseEscapesQuot :: Assertion
+caseEscapesQuot = do
+    let doc = Res.Document (Res.Prologue [] Nothing [])
+                (Res.Element "a" (Map.fromList [("attr", "\"val\"")])
+                    [])
+                []
+        result = Res.renderLBS def doc
+    result `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a attr=\"&quot;val&quot;\"/>"

--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -573,8 +573,8 @@ casePreservesAttrOrder :: Assertion
 casePreservesAttrOrder = do
     let doc = Document (Prologue [] Nothing [])
                 (Element "doc" [] [
-                  NodeElement (Element "el" [("attr1", ["1"]), ("attr2", ["2"])] []),
-                  NodeElement (Element "el" [("attr2", ["2"]), ("attr1", ["1"])] [])
+                  NodeElement (Element "el" [("attr1", [ContentText "1"]), ("attr2", [ContentText "2"])] []),
+                  NodeElement (Element "el" [("attr2", [ContentText "2"]), ("attr1", [ContentText "1"])] [])
                 ])
                 []
         rendered = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><doc><el attr1=\"1\" attr2=\"2\"/><el attr2=\"2\" attr1=\"1\"/></doc>"


### PR DESCRIPTION
This introduces ~two~ three changes aimed at improving this package for the use on xml files written and read by humans.

1. Escape *'* and *"* as *\&apos;* and *\&quot;* intead of as character refs (I don't care that much about this change and could drop it again, if desired).
2. Don't escape things that did not need to be escaped. Importantly (to me), this brings the package a bit closer to *render&nbsp;.&nbsp;parse&nbsp;=&nbsp;id*. We do however still always escape *>* in element contents. We only have to do that if it appears as a part of *]]>*, but I was to lazy to find out how to best make that happen.
3. Make the parser preserve the order of attributes. Previously it would reverse them, so that *render . parse* would turn *\<el a='' b=''>* into *\<el b='' a=''>*. This is of course not relevant when parsing to the types from `Text.Xml` as these use `Map`s to store the attributes and thus obliterate the order anyway.