### PR TITLE
Support for GHC 9.2 requires cabal-doctest >= 1.0.9

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,5 @@ packages:
 - xml-conduit/
 - xml-hamlet/
 - html-conduit/
+extra-deps:
+- cabal-doctest-1.0.9@sha256:b1fe3f3cc590c6d2c5ce8d5845e41a8a7d72621ed897b6c53312c1e772c2ab29,1467

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -17,7 +17,7 @@ extra-source-files: README.md
 tested-with:     GHC >=8.0 && <8.12
 
 custom-setup
-    setup-depends:   base >= 4 && <5, Cabal, cabal-doctest >= 1 && <1.1
+    setup-depends:   base >= 4 && <5, Cabal, cabal-doctest >= 1.0.9 && <1.1
 
 library
     build-depends:   base                      >= 4.12     && < 5


### PR DESCRIPTION
Follow-up of https://github.com/snoyberg/xml/issues/170 .

Let's try and upgrade `cabal-doctest` to support GHC 9.2 . See https://github.com/haskellari/cabal-doctest/pull/72 .