### PR TITLE
Allow transformers-0.6 series

### DIFF
--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -29,7 +29,7 @@ library
                    , containers                >= 0.2
                    , xml-types                 >= 0.3.4    && < 0.4
                    , attoparsec                >= 0.10
-                   , transformers              >= 0.2      && < 0.6
+                   , transformers              >= 0.2      && < 0.7
                    , data-default-class
                    , blaze-markup              >= 0.5
                    , blaze-html                >= 0.5


### PR DESCRIPTION
Tested using

    cabal build --constraint='transformers>=0.6' xml-conduit --disable-tests

The tests couldn't be run because they use `doctest` which uses `ghc` which uses `transformers-0.5`.
