### PR TITLE
Allow resourcet 1.3

### DIFF
--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -23,7 +23,7 @@ library
     build-depends:   base                      >= 4.12     && < 5
                    , conduit                   >= 1.3      && < 1.4
                    , conduit-extra             >= 1.3      && < 1.4
-                   , resourcet                 >= 1.2      && < 1.3
+                   , resourcet                 >= 1.2      && < 1.4
                    , bytestring                >= 0.10.2
                    , text                      >= 0.7
                    , containers                >= 0.2


### PR DESCRIPTION
This passed locally:

```
$ cd xml-conduit
$ for action in build test ; do cabal $action --enable-tests --constrain 'resourcet == 1.3.0' || break ; done
```