### PR TITLE
Normalize line endings

### DIFF
--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -57,6 +57,8 @@ main = hspec $ do
         it "preserves the order of attributes" casePreservesAttrOrder
         context "correctly parses hexadecimal entities" hexEntityParsing
         it "normalizes line endings" crlfToLfConversion
+        it "normalizes \\r at the end of a content" crlfToLfConversionCrAtEnd
+        it "normalizes multiple \\rs and \\r\\ns" crlfToLfConversionCrCrCr
     describe "XML Cursors" $ do
         it "has correct parent" cursorParent
         it "has correct ancestor" cursorAncestor
@@ -1074,3 +1076,14 @@ crlfToLfConversion = (elementContent $ documentRoot crlfDoc) `shouldBe` crlfCont
         crlfDoc = D.parseLBS_ def "<crlf>Hello,\rWorld!\r\nWe don't like your kind of line endings around here.\r\n</crlf>"
         crlfContent = [ContentText "Hello,\nWorld!\nWe don't like your kind of line endings around here.\n"]
 
+crlfToLfConversionCrAtEnd :: Assertion
+crlfToLfConversionCrAtEnd = (elementContent $ documentRoot doc) `shouldBe` content
+    where
+        doc = D.parseLBS_ def "<crlf>Hello, World!\r</crlf>"
+        content = [ContentText "Hello, World!\n"]
+
+crlfToLfConversionCrCrCr :: Assertion
+crlfToLfConversionCrCrCr = (elementContent $ documentRoot doc) `shouldBe` content
+    where
+        doc = D.parseLBS_ def "<crlf>\r\r\r\n\r\r\r</crlf>"
+        content = [ContentText "\n\n\n\n\n\n"]

--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -56,6 +56,7 @@ main = hspec $ do
         it "escapes <>'\"& as necessary" caseEscapesAsNecessary
         it "preserves the order of attributes" casePreservesAttrOrder
         context "correctly parses hexadecimal entities" hexEntityParsing
+        it "normalizes line endings" crlfToLfConversion
     describe "XML Cursors" $ do
         it "has correct parent" cursorParent
         it "has correct ancestor" cursorAncestor
@@ -1066,3 +1067,10 @@ caseEscapesCDATA = do
                 []
         result = Res.renderLBS (def { Res.rsUseCDATA = const True }) doc
     result `shouldBe` "<?xml version=\"1.0\" encoding=\"UTF-8\"?><a><![CDATA[]]]]><![CDATA[>]]></a>"
+
+crlfToLfConversion :: Assertion
+crlfToLfConversion = (elementContent $ documentRoot crlfDoc) `shouldBe` crlfContent
+    where
+        crlfDoc = D.parseLBS_ def "<crlf>Hello,\rWorld!\r\nWe don't like your kind of line endings around here.\r\n</crlf>"
+        crlfContent = [ContentText "Hello,\nWorld!\nWe don't like your kind of line endings around here.\n"]
+


### PR DESCRIPTION
XML demands that `\r` and `\r\n` are replaced by `\n` by the XML processor [Section 2.11](https://www.w3.org/TR/REC-xml/#sec-line-ends). This PR adds this feature.

This PR might break compatitbility for many users.