### PR TITLE
Don't allow `[` or `]` in XML names.

### DIFF
--- a/xml-conduit/src/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/src/Text/XML/Stream/Parse.hs
@@ -587,6 +587,8 @@ parseIdent =
     valid '/'  = False
     valid ';'  = False
     valid '#'  = False
+    valid '['  = False
+    valid ']'  = False
     valid c    = not $ isXMLSpace c
 
 parseContent :: ParseSettings

--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -735,7 +735,7 @@ testRenderComments =do
 
 resolvedInline :: Assertion
 resolvedInline = do
-    Res.Document _ root _ <- return $ Res.parseLBS_ Res.def "<!DOCTYPE foo [<!ENTITY bar \"baz\">]><foo>&bar;</foo>"
+    Res.Document _ root _ <- return $ Res.parseLBS_ Res.def "<!DOCTYPE foo[<!ENTITY bar \"baz\">]><foo>&bar;</foo>"
     root @?= Res.Element "foo" Map.empty [Res.NodeContent "baz"]
     Res.Document _ root2 _ <- return $ Res.parseLBS_ Res.def "<!DOCTYPE foo [<!ENTITY bar \"baz\">]><foo bar='&bar;'/>"
     root2 @?= Res.Element "foo" (Map.singleton "bar" "baz") []


### PR DESCRIPTION
This is an example of a DOCTYPE that was not being parsed correctly before:

```
<!DOCTYPE language[
  <!ENTITY nmtoken "[\-\w\d\.:_]+">
  <!ENTITY entref  "(#[0-9]+|#[xX][0-9A-Fa-f]+|&nmtoken;);">
]>
```

xml-conduit was parsing `language[` as the root element name.

I have kept to the most minimal possible change in this PR, because I don't want to break anything inadvertently. However, the current parser is still far from correct. As I understand it, only a few symbols (`_`, `-`, `.`) are allowed in element names (in addition, `:` can be used for a namespace, but that is supported separately in this parser).  The current parser would accept things like `<foo~bar>`.