### PR TITLE
Add option for recovering parser

### DIFF
--- a/xml-conduit/src/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/src/Text/XML/Stream/Parse.hs
@@ -83,6 +83,7 @@ module Text.XML.Stream.Parse
     , psRetainNamespaces
     , psEntityExpansionSizeLimit
     , psIgnoreInternalEntityDeclarations
+    , psRecoverFromParseFailure
       -- *** Entity decoding
     , decodeXmlEntities
     , decodeHtmlEntities
@@ -470,6 +471,7 @@ data ParseSettings = ParseSettings
     -- ^ Whether to resolve any but the predefined entities.
     --
     -- Default: @False@
+    , psRecoverFromParseFailure :: Bool
     }
 
 instance Default ParseSettings where
@@ -479,6 +481,7 @@ instance Default ParseSettings where
         , psDecodeIllegalCharacters = const Nothing
         , psEntityExpansionSizeLimit = 8192
         , psIgnoreInternalEntityDeclarations = False
+        , psRecoverFromParseFailure = False
         }
 
 conduitToken :: MonadThrow m => ParseSettings -> ConduitT T.Text (PositionRange, Token) m ()
@@ -488,7 +491,9 @@ parseToken :: ParseSettings -> Parser Token
 parseToken settings = do
   mbc <- peekChar
   case mbc of
-    Just '<' -> char '<' >> parseLt
+    Just '<' -> if psRecoverFromParseFailure settings
+                then (char '<' >> parseLt) <|> (TokenContent <$> parseContent settings False False)
+                else char '<' >> parseLt
     _        -> TokenContent <$> parseContent settings False False
   where
     parseLt = do
@@ -643,7 +648,14 @@ parseContent :: ParseSettings
              -> Bool -- break on double quote
              -> Bool -- break on single quote
              -> Parser Content
-parseContent (ParseSettings decodeEntities _ decodeIllegalCharacters _ _) breakDouble breakSingle = parseReference <|> (parseTextContent <?> "text content") where
+parseContent (ParseSettings decodeEntities _ decodeIllegalCharacters _ _ recover) breakDouble breakSingle = parseReference <|> contentParser where
+  contentParser =
+      if recover
+      then (parseTextContent <?> "text content") <|> parseFailingChar
+      else parseTextContent <?> "text content"
+  parseFailingChar = do
+    c <- char '&' <|> char '<' <|> char '>'
+    return $ ContentText $ T.singleton c
   parseReference = do
     char' '&'
     t <- parseEntityRef <|> parseHexCharRef <|> parseDecCharRef


### PR DESCRIPTION
We're sometimes confronted with managing malformed XML data that we can't fix because we didn't generate it and we don't have the possibilities to fix it upstream: these XML files come from somewhere outside of our control. We should still need to be able to parse them at least partially, if possible. So I added a recovery mode to `xml-conduit`, similar to what exists in [lxml with the option **recover**](https://lxml.de/api/lxml.etree.iterparse-class.html). The target of this recovering parser is mainly unescaped characters.