### PR TITLE
data-default-class -> data-default

### DIFF
--- a/xml-conduit/src/Text/XML/Stream/Parse.hs
+++ b/xml-conduit/src/Text/XML/Stream/Parse.hs
@@ -161,7 +161,7 @@ import qualified Data.ByteString.Builder      as Builder
 import           Data.Char                    (isSpace)
 import           Data.Conduit.Attoparsec      (PositionRange, conduitParser)
 import qualified Data.Conduit.Text            as CT
-import           Data.Default.Class           (Default (..))
+import           Data.Default           (Default (..))
 import           Data.List                    (foldl', intercalate)
 import qualified Data.Map                     as Map
 import           Data.Maybe                   (fromMaybe, isNothing, mapMaybe)

--- a/xml-conduit/src/Text/XML/Stream/Render.hs
+++ b/xml-conduit/src/Text/XML/Stream/Render.hs
@@ -35,7 +35,7 @@ import           Control.Monad.Trans.Resource (MonadThrow)
 import           Data.ByteString              (ByteString)
 import           Data.ByteString.Builder      (Builder)
 import           Conduit
-import           Data.Default.Class           (Default (def))
+import           Data.Default           (Default (def))
 import           Data.List                    (foldl')
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map

--- a/xml-conduit/xml-conduit.cabal
+++ b/xml-conduit/xml-conduit.cabal
@@ -30,7 +30,7 @@ library
                    , xml-types                 >= 0.3.4    && < 0.4
                    , attoparsec                >= 0.10
                    , transformers              >= 0.2      && < 0.7
-                   , data-default-class
+                   , data-default
                    , blaze-markup              >= 0.5
                    , blaze-html                >= 0.5
                    , deepseq                   >= 1.1.0.0


### PR DESCRIPTION
data-default 0.8 deprecates data-default-class by moving the `Default` class from `Data.Default.Class` to `Data.Default`.

See: https://github.com/commercialhaskell/stackage/issues/7545