### PR TITLE
Add Stream.Render.document function

### DIFF
--- a/xml-conduit/src/Text/XML/Stream/Render.hs
+++ b/xml-conduit/src/Text/XML/Stream/Render.hs
@@ -19,6 +19,7 @@ module Text.XML.Stream.Render (
     orderAttrs,
 
     -- * Event rendering
+    xmlDeclaration,
     tag,
     content,
 

--- a/xml-conduit/src/Text/XML/Stream/Render.hs
+++ b/xml-conduit/src/Text/XML/Stream/Render.hs
@@ -19,7 +19,7 @@ module Text.XML.Stream.Render (
     orderAttrs,
 
     -- * Event rendering
-    xmlDeclaration,
+    document,
     tag,
     content,
 

--- a/xml-conduit/src/Text/XML/Stream/Render/Internal.hs
+++ b/xml-conduit/src/Text/XML/Stream/Render/Internal.hs
@@ -21,6 +21,7 @@ module Text.XML.Stream.Render.Internal
     , rsXMLDeclaration
     , orderAttrs
       -- * Event rendering
+    , xmlDeclaration
     , tag
     , content
       -- * Attribute rendering
@@ -82,7 +83,12 @@ data RenderSettings = RenderSettings
       --
       -- @since 1.3.3
     , rsXMLDeclaration :: Bool
-      -- ^ Determines whether the XML declaration will be output.
+      -- ^ Determines whether the XML declaration will be output. Note that when
+      -- using the streaming API the XML declaration will be output only if this
+      -- is set to true /and/ the stream includes an 'EventBeginDocument' event.
+      -- This can be achieved with the 'xmlDeclaration' function.
+      --
+      -- See <https://github.com/snoyberg/xml/issues/129>.
       --
       -- Default: @True@
       --
@@ -391,6 +397,12 @@ nubAttrs orig =
         | k `Set.member` used = (dlist, used)
         | otherwise = (dlist . ((k, v):), Set.insert k used)
 
+-- | Generate an 'EventBeginDocument' which results in an XML declaration being
+-- output when rendered.
+--
+-- @since TODO
+xmlDeclaration :: (Monad m) => ConduitT i Event m ()
+xmlDeclaration = yield EventBeginDocument
 
 -- | Generate a complete XML 'Element'.
 tag :: (Monad m) => Name -> Attributes -> ConduitT i Event m ()  -- ^ 'Element''s subnodes.

--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -1122,7 +1122,7 @@ streamRenderGenerateEvents = do
         nonEmptyDoc @?=
             [ EventBeginDocument
             , EventBeginElement "foo" []
-            , EventContent "..."
+            , EventContent $ ContentText "..."
             , EventEndElement "foo"
             , EventEndDocument
             ]
@@ -1133,7 +1133,7 @@ streamRenderGenerateEvents = do
             R.tag "foo" (R.attr "bar" "baz") (R.content "...") .| sinkList
         nonEmptyTag @?=
             [ EventBeginElement "foo" [("bar", ["baz"])]
-            , EventContent "..."
+            , EventContent $ ContentText "..."
             , EventEndElement "foo"
             ]
 
@@ -1144,8 +1144,8 @@ streamRender = do
   where
     input = yieldMany
         [ EventBeginDocument
-        , EventBeginElement "foo" [("bar", ["baz"])]
-        , EventContent "..."
+        , EventBeginElement "foo" [("bar", [ContentText "baz"])]
+        , EventContent $ ContentText "..."
         , EventEndElement "foo"
         , EventEndDocument
         ]

--- a/xml-conduit/test/unit.hs
+++ b/xml-conduit/test/unit.hs
@@ -1132,7 +1132,7 @@ streamRenderGenerateEvents = do
         nonEmptyTag <- runConduit $
             R.tag "foo" (R.attr "bar" "baz") (R.content "...") .| sinkList
         nonEmptyTag @?=
-            [ EventBeginElement "foo" [("bar", ["baz"])]
+            [ EventBeginElement "foo" [("bar", [ContentText "baz"])]
             , EventContent $ ContentText "..."
             , EventEndElement "foo"
             ]


### PR DESCRIPTION
Hi,

The new `xmlDeclaration` function introduced by this PR makes the solution proposed in #129 part of the API.

I wondered how to add an XML declaration to the rendered XML produced by the streaming API, found nothing in the docs and finally stumbled upon this issue where it is explained. I figured this should be properly documented in the Haddocks or even provided as an - albeit very simple - function.

Should you be opposed to adding new functions to the API we should at least add a note to the docs so the issue mentioned above is not the only place where this info can be found.

Cheers,
Martin